### PR TITLE
feat(#9): 학생 페이지 problempanel 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { Header } from './components/student-class/Header';
+import React from 'react';
+import StudentClassPage from './pages/StudentClassPage';
 
 function App() {
-  return <Header />;
+  return <StudentClassPage />;
 }
 
 export default App;

--- a/src/assets/back.svg
+++ b/src/assets/back.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#fff" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+</svg> 

--- a/src/assets/play.svg
+++ b/src/assets/play.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 3L20 12L6 21V3Z" stroke="#FFFAFA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg> 

--- a/src/components/student-class/ProblemPanel/ProblemDetailView.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemDetailView.tsx
@@ -1,0 +1,276 @@
+/*
+ * ======================================================================
+ * 문제 상세 뷰(ProblemDetailView) 컴포넌트
+ * ----------------------------------------------------------------------
+ * - `ProblemPanel`의 자식 컴포넌트로, 선택된 문제의 상세 정보를 표시합니다.
+ * - '문제' 탭과 '테스트' 탭을 가지며, 사용자는 탭을 전환하며 문제 설명과 테스트케이스를 확인할 수 있습니다.
+ * - Python 코드 실행(채점) 기능을 제공하며, 실행 결과를 사용자에게 보여줍니다.
+ *
+ * 주요 로직 및 하위 컴포넌트:
+ * - Tabs: '문제'와 '테스트' 탭 UI 및 상태 전환 로직을 관리합니다.
+ * - ProblemDescription: '문제' 탭 선택 시 보이며, 문제의 제목과 설명을 렌더링합니다.
+ * - TestCaseViewer: '테스트' 탭 선택 시 보이며, `TestCaseItem`들을 리스트 형태로 보여줍니다.
+ * - TestCaseItem:
+ *   - 개별 테스트케이스를 나타내는 가장 핵심적인 컴포넌트입니다.
+ *   - '실행' 버튼 클릭 시 `handleRunTest` 함수를 호출하여 props로 받은 `pyodide` 인스턴스를 사용해 `userCode`를 실행합니다.
+ *   - 코드 실행 전, `pyodide.globals.set`을 이용해 테스트케이스의 입력을 파이썬 환경의 변수로 설정하고,
+ *     `sys.stdin`을 리다이렉트하여 `input()` 함수가 해당 변수를 읽도록 설정합니다.
+ *   - `pyodide.setStdout`을 통해 표준 출력을 캡처하여 `output` 상태에 저장합니다.
+ *   - 실행 결과(`output`)와 기대 결과(`expectedOutput`)를 비교하여 정답/오답 여부를 UI에 표시합니다.
+ *
+ * 주요 상태(State):
+ * - activeTab: 현재 활성화된 탭('problem' 또는 'test')을 저장합니다.
+ * - (TestCaseItem 내부) isRunning: 테스트 실행 중인지 여부를 나타내어 버튼을 비활성화하는 데 사용됩니다.
+ * - (TestCaseItem 내부) output: 코드 실행 후의 표준 출력 결과.
+ * - (TestCaseItem 내부) error: 코드 실행 중 발생한 에러 메시지.
+ *
+ * 주요 props:
+ * - problem: 표시할 문제의 상세 정보 (id, title, description).
+ * - testCases: 해당 문제에 대한 테스트케이스 배열.
+ * - onBackToList: '목록으로' 버튼 클릭 시 실행될 콜백 함수. 부모의 `selectedProblemId`를 `null`로 설정합니다.
+ * - onSubmit: '제출하기' 버튼 클릭 시 실행될 콜백 함수.
+ * - userCode: 사용자가 에디터에 작성한 코드. `TestCaseItem`에서 실행됩니다.
+ * - pyodide: 코드 실행을 위한 Pyodide 인스턴스.
+ * ======================================================================
+ */
+import React, { useState } from 'react';
+import backIcon from '../../../assets/back.svg';
+import playIcon from '../../../assets/play.svg';
+import type { Pyodide } from '../../../types/pyodide';
+
+// ===================== 타입 정의 =====================
+// TODO: 실제 데이터 연동 시 아래 타입만 교체하면 됩니다.
+type IProblemDetail = { id: string; title: string; description: string };
+type ITestCase = { id: number; input: string; expectedOutput: string };
+
+// ===================== props 타입 =====================
+interface ProblemDetailViewProps {
+  problem: IProblemDetail; // 문제 정보
+  testCases: ITestCase[]; // 테스트케이스 배열
+  onBackToList: () => void; // 문제 목록으로 돌아가기
+  onSubmit: () => void; // 제출 버튼 클릭 시 실행 함수
+  userCode: string; // 학생이 작성한 코드
+  pyodide: Pyodide | null; // pyodide 인스턴스 (파이썬 실행 환경)
+}
+
+/*
+ * ======================================================================
+ * Tabs: 문제/테스트 탭 전환 컴포넌트
+ * ======================================================================
+ */
+const Tabs: React.FC<{
+  activeTab: string;
+  setActiveTab: (tab: 'problem' | 'test') => void;
+}> = ({ activeTab, setActiveTab }) => {
+  const getTabClass = (tabName: 'problem' | 'test') =>
+    `w-1/2 py-2 text-sm font-medium rounded-md flex items-center justify-center gap-2 transition-colors ${activeTab === tabName ? 'bg-slate-600 text-white' : 'text-slate-300 hover:bg-slate-700'}`;
+  return (
+    <div className="flex w-full bg-slate-800 p-1 rounded-lg">
+      <button
+        onClick={() => setActiveTab('problem')}
+        className={getTabClass('problem')}
+      >
+        문제
+      </button>
+      <button
+        onClick={() => setActiveTab('test')}
+        className={getTabClass('test')}
+      >
+        테스트
+      </button>
+    </div>
+  );
+};
+
+/*
+ * ======================================================================
+ * ProblemDescription: 문제 설명 컴포넌트
+ * ======================================================================
+ */
+const ProblemDescription: React.FC<{ problem: IProblemDetail }> = ({
+  problem,
+}) => (
+  <div className="text-slate-300 space-y-6">
+    <h2 className="text-2xl font-bold text-white">{problem.title}</h2>
+    <p className="text-sm">{problem.description}</p>
+  </div>
+);
+
+/*
+ * ======================================================================
+ * TestCaseItem: 개별 테스트케이스 실행/채점 컴포넌트
+ * - pyodide로 코드 실행, 결과/에러/정답여부 표시
+ * ======================================================================
+ */
+const TestCaseItem: React.FC<{
+  testCase: ITestCase;
+  userCode: string;
+  pyodide: Pyodide | null;
+}> = ({ testCase, userCode, pyodide }) => {
+  // 실행 상태 및 결과 관리
+  const [isRunning, setIsRunning] = useState(false);
+  const [output, setOutput] = useState('');
+  const [error, setError] = useState('');
+
+  // ===================== 채점(실행) 로직 =====================
+  const handleRunTest = async () => {
+    if (!pyodide || !userCode) return;
+    setIsRunning(true);
+    setOutput('');
+    setError('');
+    try {
+      // 입력값 세팅 및 표준입력 리다이렉트
+      pyodide.globals.set('test_input', testCase.input);
+      pyodide.runPython(
+        `import sys; from io import StringIO; sys.stdin = StringIO(test_input)`,
+      );
+      let capturedOutput = '';
+      // 표준출력 캡처
+      pyodide.setStdout({
+        batched: (out: string) => {
+          capturedOutput += out + '\n';
+        },
+      });
+      // 코드 실행
+      await pyodide.runPythonAsync(userCode);
+      setOutput(capturedOutput.trim());
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      pyodide.setStdout({});
+      setIsRunning(false);
+    }
+  };
+  // ===================== 정답/오답 판정 =====================
+  const isCorrect = output && output.trim() === testCase.expectedOutput.trim();
+
+  return (
+    <div className="bg-slate-700 p-3 rounded-md">
+      <div className="flex justify-between items-center mb-2">
+        <h4 className="font-semibold text-white text-sm">
+          Test Case {testCase.id}
+        </h4>
+        <button
+          onClick={handleRunTest}
+          disabled={isRunning}
+          className="disabled:opacity-50"
+        >
+          {isRunning ? (
+            <img
+              src={playIcon}
+              alt="실행 중"
+              className="w-5 h-5 animate-spin"
+            />
+          ) : (
+            <img
+              src={playIcon}
+              alt="실행"
+              className="w-5 h-5 text-slate-400 hover:text-white"
+            />
+          )}
+        </button>
+      </div>
+      <div className="text-xs font-mono text-slate-400 space-y-1">
+        <p>
+          <strong>입력:</strong> {testCase.input}
+        </p>
+        <p>
+          <strong>기대 출력:</strong> {testCase.expectedOutput}
+        </p>
+        {output && (
+          <p>
+            <strong>실제 출력:</strong> {output}
+            <span
+              className={
+                isCorrect ? 'text-green-400 ml-2' : 'text-red-400 ml-2'
+              }
+            >
+              {isCorrect ? '정답' : '오답'}
+            </span>
+          </p>
+        )}
+        {error && (
+          <p className="text-red-400">
+            <strong>에러:</strong> {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/*
+ * ======================================================================
+ * TestCaseViewer: 테스트케이스 목록 컴포넌트
+ * ======================================================================
+ */
+const TestCaseViewer: React.FC<{
+  testCases: ITestCase[];
+  userCode: string;
+  pyodide: Pyodide | null;
+}> = ({ testCases, userCode, pyodide }) => (
+  <div className="space-y-4">
+    {testCases.map((tc) => (
+      <TestCaseItem
+        key={tc.id}
+        testCase={tc}
+        userCode={userCode}
+        pyodide={pyodide}
+      />
+    ))}
+  </div>
+);
+
+/*
+ * ======================================================================
+ * ProblemDetailView: 메인 컴포넌트 (props로 모든 데이터/핸들러 받음)
+ * ======================================================================
+ */
+export const ProblemDetailView: React.FC<ProblemDetailViewProps> = ({
+  problem,
+  testCases,
+  onBackToList,
+  onSubmit,
+  userCode,
+  pyodide,
+}) => {
+  // 탭 상태 관리 ('problem': 문제 설명, 'test': 테스트케이스)
+  const [activeTab, setActiveTab] = useState<'problem' | 'test'>('problem');
+  return (
+    <div className="p-4 flex flex-col h-full">
+      <header className="flex-shrink-0">
+        <button
+          onClick={onBackToList}
+          className="text-sm text-slate-400 hover:text-white mb-4 flex items-center gap-1"
+        >
+          <img src={backIcon} alt="뒤로가기" className="w-4 h-4 inline-block" />{' '}
+          문제 목록으로
+        </button>
+        <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
+      </header>
+      <main className="flex-grow mt-6 overflow-y-auto pr-2">
+        {activeTab === 'problem' ? (
+          <ProblemDescription problem={problem} />
+        ) : (
+          <TestCaseViewer
+            testCases={testCases}
+            userCode={userCode}
+            pyodide={pyodide}
+          />
+        )}
+      </main>
+      {activeTab === 'problem' && (
+        <footer className="flex-shrink-0 mt-6 pt-4 border-t border-slate-700">
+          <button
+            onClick={onSubmit}
+            className="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md"
+          >
+            제출하기
+          </button>
+        </footer>
+      )}
+    </div>
+  );
+};
+
+export default ProblemDetailView;

--- a/src/components/student-class/ProblemPanel/ProblemListView.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemListView.tsx
@@ -1,0 +1,88 @@
+/*
+ * ======================================================================
+ * 문제 목록 뷰(ProblemListView) 컴포넌트
+ * ----------------------------------------------------------------------
+ * - `ProblemPanel`의 자식 컴포넌트로, 전체 문제 리스트를 표시하는 역할을 합니다.
+ * - 각 문제의 제목과 현재 상태(통과, 실패, 미해결)를 시각적으로 보여줍니다.
+ *
+ * 주요 로직:
+ * - `problems` 배열을 props로 받아 `map` 함수를 통해 각 문제를 `ProblemListItem` 컴포넌트로 렌더링합니다.
+ * - 사용자가 특정 문제를 클릭하면, `onSelectProblem` 콜백 함수를 호출하여 선택된 문제의 `id`를 부모 컴포넌트(`ProblemPanel`)로 전달합니다.
+ *
+ * `ProblemListItem` 내부 로직:
+ * - 문제의 `status` 값('pass', 'fail', 'none')에 따라 다른 배경색과 텍스트를 가진 뱃지를 표시하여 상태를 시각화합니다.
+ *
+ * 주요 props:
+ * - problems: 표시할 문제 객체들의 배열. 각 객체는 id, title, status 등을 포함합니다.
+ * - onSelectProblem: 문제 항목이 클릭되었을 때 실행될 콜백 함수. 인자로 문제의 `id`를 받습니다.
+ * ======================================================================
+ */
+import React from 'react';
+// TODO: 실제 데이터 연결 시 아래 타입/데이터 부분만 교체하면 됩니다.
+type IProblem = {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pass' | 'fail' | 'none';
+};
+
+/*
+ * ======================================================================
+ * 개별 문제 항목(ProblemListItem) 컴포넌트
+ * - 문제 목록의 각 아이템을 나타냅니다.
+ * - 문제의 제목과 상태(pass/fail/none)에 따른 뱃지를 표시합니다.
+ * - 클릭 시 `onSelect` 함수를 호출하여 문제 선택 이벤트를 처리합니다.
+ * ======================================================================
+ */
+const ProblemListItem: React.FC<{
+  problem: IProblem;
+  onSelect: (id: string) => void;
+}> = ({ problem, onSelect }) => {
+  // 상태별 뱃지 색상 클래스
+  const statusClasses = {
+    pass: 'bg-green-600 text-green-100',
+    fail: 'bg-red-600 text-red-100',
+    none: 'bg-slate-500 text-slate-100',
+  };
+  return (
+    <button
+      onClick={() => onSelect(problem.id)}
+      className="w-full p-3 rounded-md text-left transition-colors flex justify-between items-center bg-slate-700 hover:bg-slate-600"
+    >
+      <span className="font-medium text-sm text-white">{problem.title}</span>
+      <span
+        className={`px-2 py-0.5 text-xs font-semibold rounded-full ${statusClasses[problem.status]}`}
+      >
+        {problem.status}
+      </span>
+    </button>
+  );
+};
+
+/*
+ * ======================================================================
+ * 문제 목록 뷰(ProblemListView) 메인
+ * - `problems` 배열을 받아 `ProblemListItem`으로 렌더링합니다.
+ * ======================================================================
+ */
+export const ProblemListView: React.FC<{
+  problems: IProblem[];
+  onSelectProblem: (id: string) => void;
+}> = ({ problems, onSelectProblem }) => (
+  <div className="p-4 h-full flex flex-col">
+    <h2 className="text-xl font-semibold text-white mb-4 flex-shrink-0">
+      문제 선택
+    </h2>
+    <div className="flex-grow overflow-y-auto pr-2 space-y-2">
+      {problems.map((problem) => (
+        <ProblemListItem
+          key={problem.id}
+          problem={problem}
+          onSelect={onSelectProblem}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export default ProblemListView;

--- a/src/components/student-class/ProblemPanel/ProblemPanel.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemPanel.tsx
@@ -1,0 +1,147 @@
+/*
+ * ======================================================================
+ * 문제 패널(ProblemPanel) 메인 컴포넌트
+ * ----------------------------------------------------------------------
+ * - 학생 페이지 사이드에 위치하며, 문제 목록과 상세 내용을 표시합니다.
+ * - 문제 목록 (ProblemListView)과 문제 상세 (ProblemDetailView) 두 개의 자식 컴포넌트를 조건부로 렌더링합니다.
+ * - Pyodide (클라이언트 사이드 Python 실행 환경) 인스턴스를 관리하고,
+ *   실행에 필요한 상태(pyodide, isPyodideLoading)를 자식에게 전달합니다.
+ * - 어떤 문제가 선택되었는지(selectedProblemId) 상태를 관리하여 뷰 전환을 처리합니다.
+ *
+ * 주요 상태(State):
+ * - selectedProblemId: 현재 선택된 문제의 ID. null이면 목록 뷰, 값이 있으면 상세 뷰를 표시합니다.
+ * - pyodide: Pyodide 라이브러리 인스턴스. Python 코드 실행을 담당합니다.
+ * - isPyodideLoading: Pyodide 라이브러리 로딩 상태. 로딩 중 UI를 표시하는 데 사용됩니다.
+ *
+ * 주요 props:
+ * - userCode: 상위 컴포넌트(아마도 코드 에디터)에서 관리하는 사용자의 코드 문자열.
+ * - onSubmit: 사용자가 '제출하기' 버튼을 눌렀을 때 실행될 콜백 함수.
+ *
+ * 데이터 흐름:
+ * 1. 컴포넌트 마운트 시 `useEffect`를 통해 Pyodide를 비동기적으로 로드하고 `pyodide` 상태를 업데이트합니다.
+ * 2. `ProblemListView`에 문제 목록(`mockProblems`)과 선택 핸들러(`setSelectedProblemId`)를 전달합니다.
+ * 3. 사용자가 `ProblemListView`에서 특정 문제를 클릭하면 `setSelectedProblemId`가 호출되어 `selectedProblemId` 상태가 변경됩니다.
+ * 4. `selectedProblemId`가 변경되면, `useMemo`를 통해 `selectedProblem`과 `selectedTestCases`가 다시 계산됩니다.
+ * 5. `selectedProblem`이 존재하면 `ProblemDetailView`가 렌더링되며, 필요한 모든 데이터와 핸들러를 props로 전달받습니다.
+ * 6. 사용자가 `ProblemDetailView`에서 '목록으로' 버튼을 클릭하면 `setSelectedProblemId(null)`이 호출되어 다시 목록 뷰로 전환됩니다.
+ * ======================================================================
+ */
+import React, { useState, useMemo, useEffect } from 'react';
+import ProblemListView from './ProblemListView.tsx'; // 문제 목록 뷰
+import ProblemDetailView from './ProblemDetailView.tsx'; // 문제 상세 뷰
+import type { Pyodide } from '../../../types/pyodide';
+
+// TODO: 실제 데이터 연동 시 아래 mock 데이터만 교체하면 됩니다.
+interface IProblem {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pass' | 'fail' | 'none';
+}
+interface ITestCase {
+  id: number;
+  input: string;
+  expectedOutput: string;
+}
+
+const mockProblems: IProblem[] = [
+  {
+    id: '1',
+    title: 'A+B 문제',
+    description: '두 수를 입력받아 더하는 문제',
+    status: 'none',
+  },
+  {
+    id: '2',
+    title: '최대공약수',
+    description: '두 수의 최대공약수를 구하는 문제',
+    status: 'none',
+  },
+];
+const mockTestCases: Record<string, ITestCase[]> = {
+  '1': [{ id: 1, input: '1 2', expectedOutput: '3' }],
+  '2': [{ id: 1, input: '12 18', expectedOutput: '6' }],
+};
+
+// ProblemPanel이 받을 props 타입 정의
+interface ProblemPanelProps {
+  userCode: string; // 학생이 작성한 코드
+  onSubmit: () => void; // 제출 버튼 클릭 시 실행 함수
+}
+
+/*
+ * ======================================================================
+ * ProblemPanel 컴포넌트
+ * - 문제 목록/상세, pyodide 환경, 테스트케이스 등 상태 관리
+ * - userCode, onSubmit 등 props로 받아 하위로 전달
+ * ======================================================================
+ */
+export const ProblemPanel: React.FC<ProblemPanelProps> = ({
+  userCode,
+  onSubmit,
+}) => {
+  // 현재 선택된 문제 id (null이면 목록 화면)
+  const [selectedProblemId, setSelectedProblemId] = useState<string | null>(
+    null,
+  );
+  // pyodide 인스턴스 (파이썬 실행 환경)
+  const [pyodide, setPyodide] = useState<Pyodide | null>(null);
+  // pyodide 로딩 상태
+  const [isPyodideLoading, setIsPyodideLoading] = useState(true);
+
+  // pyodide 초기화 (최초 1회)
+  useEffect(() => {
+    const initPyodide = async () => {
+      try {
+        const pyodideInstance = await window.loadPyodide({
+          indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/',
+        });
+        setPyodide(pyodideInstance);
+      } catch (error) {
+        console.error('Pyodide 로드 실패:', error);
+      } finally {
+        setIsPyodideLoading(false);
+      }
+    };
+    initPyodide();
+  }, []);
+
+  // 현재 선택된 문제 객체
+  const selectedProblem = useMemo(
+    () => mockProblems.find((p) => p.id === selectedProblemId) || null,
+    [selectedProblemId],
+  );
+  // 현재 선택된 문제의 테스트케이스 배열
+  const selectedTestCases = useMemo(
+    () => (selectedProblemId ? mockTestCases[selectedProblemId] : []) || [],
+    [selectedProblemId],
+  );
+
+  return (
+    <aside className="w-[360px] bg-slate-800 border-r border-slate-700">
+      {/* pyodide 로딩 중이면 로딩 메시지 */}
+      {isPyodideLoading ? (
+        <div className="flex items-center justify-center h-full text-slate-400">
+          <span>테스트 환경 로딩 중...</span>
+        </div>
+      ) : selectedProblem ? (
+        // 문제 상세 뷰
+        <ProblemDetailView
+          problem={selectedProblem}
+          testCases={selectedTestCases}
+          onBackToList={() => setSelectedProblemId(null)}
+          onSubmit={onSubmit}
+          userCode={userCode}
+          pyodide={pyodide}
+        />
+      ) : (
+        // 문제 목록 뷰
+        <ProblemListView
+          problems={mockProblems}
+          onSelectProblem={setSelectedProblemId}
+        />
+      )}
+    </aside>
+  );
+};
+export default ProblemPanel;

--- a/src/pages/StudentClassPage.tsx
+++ b/src/pages/StudentClassPage.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { Header } from '../components/student-class/Header';
+import { ProblemPanel } from '../components/student-class/ProblemPanel/ProblemPanel';
+
+export const StudentClassPage: React.FC = () => {
+  const [userCode, _setUserCode] = useState<string>(
+    `a, b = map(int, input().split())\nprint(a + b)`,
+  );
+
+  const handleGradeSubmit = async () => {
+    alert('코드 제출! (임시 핸들러)');
+  };
+
+  return (
+    <div className="w-screen h-screen bg-slate-900 flex flex-col text-gray-200">
+      <Header />
+      <main className="flex flex-grow overflow-hidden">
+        <ProblemPanel userCode={userCode} onSubmit={handleGradeSubmit} />
+      </main>
+    </div>
+  );
+};
+export default StudentClassPage;

--- a/src/types/pyodide.d.ts
+++ b/src/types/pyodide.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Pyodide 인스턴스의 주요 메서드 타입을 정의합니다.
+ * 'any' 타입을 피하고 코드 자동 완성을 지원하기 위해 사용됩니다.
+ */
+export interface Pyodide {
+  runPythonAsync: (code: string) => Promise<any>;
+  globals: {
+    set: (name: string, value: any) => void;
+  };
+  setStdout: (options: any) => void;
+  runPython: (code: string) => any;
+}
+
+/**
+ * 전역 Window 객체에 loadPyodide 함수 타입을 선언합니다.
+ * 이를 통해 TypeScript가 window.loadPyodide를 인식할 수 있습니다.
+ */
+declare global {
+  interface Window {
+    loadPyodide: (config?: any) => Promise<Pyodide>;
+  }
+}


### PR DESCRIPTION
요약
- **문제 목록**과 **문제 상세/테스트** 뷰를 전환
- 클라이언트 사이드 채점을 위한 **Pyodide(파이썬 실행 환경)**를 로드하고 관리
- 상위 컴포넌트(`StudentClassPage`)로부터 받은 `userCode`와 `onSubmit` 함수를 필요한 하위 컴포넌트로 전달
- pyodide 로드를 위한 index.ts CDN 추가
- 필요한 아이콘 추가
- 중복 studenclasspage 삭제


ProblemPanel.tsx - 최상위 부모 역할
- **상태 관리**:
  - `selectedProblemId`: 현재 어떤 문제가 선택되었는지 ID로 관리. 이 값이 `null`이면 문제 목록(`ProblemListView`)을, ID가 있으면 문제 상세(`ProblemDetailView`)를 보여준다.
  - `pyodide`: 브라우저에서 파이썬 코드를 실행할 수 있게 해주는 `Pyodide` 인스턴스를 저장.
  - `isPyodideLoading`: `Pyodide`가 로딩 중인지 여부를 관리하여, 로딩 중에는 "테스트 환경 로딩 중..." 메시지를 표시.

- **기능**:
  - `useEffect`를 사용해 컴포넌트가 처음 렌더링될 때 `Pyodide`를 초기화.
  - `selectedProblemId`가 바뀔 때마다 `mockProblems`와 `mockTestCases`에서 현재 문제에 맞는 정보를 찾아 `ProblemDetailView`로 전달.
  - **뷰 전환 로직**: `selectedProblemId` 값에 따라 `ProblemListView`를 보여줄지, `ProblemDetailView`를 보여줄지 결정하는 삼항 연산자 로직을 가지고 있다.


ProblemListView.tsx
- **기능**:
  - `ProblemPanel`로부터 `problems` 배열을 props로 받아 목록을 화면에 그린다.
  - 각 문제(`ProblemListItem`)는 제목과 채점 상태(`pass`, `fail`, `none`)를 표시.
  - 사용자가 특정 문제를 클릭하면, `onSelectProblem` 함수를 호출하여 부모(`ProblemPanel`)의 `selectedProblemId` 상태를 업데이트합니다. 이로 인해 화면이 `ProblemDetailView`로 전환.


ProblemDetailView.tsx
- **내부 상태 관리**:
  - `activeTab`: '문제' 탭과 '테스트' 탭 중 어느 것이 활성화되었는지 관리.

- **하위 컴포넌트 및 기능**:
  - **`Tabs`**: '문제'와 '테스트' 탭 UI를 제공하고, 클릭 시 `activeTab` 상태를 변경.
  - **`ProblemDescription`**: '문제' 탭이 활성화됐을 때 문제의 제목과 상세 설명을 보여준다.
  - **`TestCaseViewer`**: '테스트' 탭이 활성화됐을 때, 여러 개의 `TestCaseItem`을 목록 형태로 보여준다.
  - **`TestCaseItem`**: **가장 중요한 채점 로직**.
    - **Pyodide 실행**: 실행(▶️) 버튼을 누르면, 부모로부터 props로 받은 `pyodide` 인스턴스와 `userCode`를 사용해 코드를 실행.
    - **결과 비교**: 코드 실행 후 나온 `output`(실제 출력)과 `testCase.expectedOutput`(기대 출력)을 비교하여 "정답" 또는 "오답"을 화면에 표시.
    - **로딩 및 에러 처리**: 코드 실행 중에는 아이콘이 회전하며, 에러가 발생하면 에러 메시지를 보여준다.
  - **제출 버튼**: '문제' 탭 하단에 있으며, 클릭 시 최상위(`StudentClassPage`)로부터 전달받은 `onSubmit` 함수를 실행한다.

 전체 데이터 및 기능 흐름 

1.  **초기 화면**: `ProblemPanel`이 렌더링되고, `Pyodide`가 백그라운드에서 로딩되는 동안 `ProblemListView`(문제 목록)가 표시된다.
2.  **문제 선택**: 사용자가 `ProblemListView`에서 'A+B 문제'를 클릭.
3.  **상태 변경**: `ProblemListView`의 `onSelectProblem` 함수가 호출되어 `ProblemPanel`의 `selectedProblemId` 상태가 '1'로 변경.
4.  **뷰 전환**: `ProblemPanel`은 `selectedProblemId`가 있으므로 `ProblemListView` 대신 `ProblemDetailView`를 렌더링. 이때 'A+B 문제'의 정보와 테스트케이스, 그리고 `userCode`와 `pyodide` 인스턴스를 `ProblemDetailView`에 props로 전달.
5.  **테스트 탭 이동**: 사용자가 `ProblemDetailView`에서 '테스트' 탭을 클릭합니다. `activeTab` 상태가 'test'로 바뀌면서 `TestCaseViewer`가 표시.
6.  **코드 실행**: 사용자가 테스트케이스 옆의 실행(▶️) 버튼을 누른다.
7.  **클라이언트 채점**: `TestCaseItem`은 props로 받은 `userCode`와 `pyodide`를 이용해 코드를 실행하고, 결과를 "정답" 또는 "오답"으로 표시.
8.  **최종 제출**: 사용자가 다시 '문제' 탭으로 돌아와 '제출하기' 버튼을 누른다. `StudentClassPage`까지 전달된 `onSubmit` 함수가 최종적으로 실행.

![image](https://github.com/user-attachments/assets/76bff2b4-0efb-4162-b194-c916bb1ab5ed)
![image](https://github.com/user-attachments/assets/3fd2babe-d558-42ed-addb-8ccd3e1f6f78)
![image](https://github.com/user-attachments/assets/6dfa791a-ba5a-4402-aa78-6aeb13a60efb)


------------------
추가
pyodide.d.ts 
Pyodide가 일반 JavaScript 파일로 만들어져 있기 때문에 . 이렇게 불러온 코드는 window.loadPyodide라는 함수를 전역적으로 사용할 수 있게 해준다.
