### PR TITLE
feat(#12):JoinPage만들기

### DIFF
--- a/src/components/join/ActionCard.tsx
+++ b/src/components/join/ActionCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+// 이 카드가 어떤 props를 받을지 명확하게 정의합니다.
+interface ActionCardProps {
+  icon: React.ReactNode;
+  iconBgColor: string;
+  title: string;
+  description: string;
+  buttonIcon: React.ReactNode;
+  buttonText: string;
+  buttonColor: string;
+  onSubmit: (e: React.FormEvent) => void;
+  children: React.ReactNode;
+}
+
+const ActionCard: React.FC<ActionCardProps> = ({
+  icon,
+  iconBgColor,
+  title,
+  description,
+  buttonIcon,
+  buttonText,
+  buttonColor,
+  onSubmit,
+  children,
+}) => (
+  <form
+    onSubmit={onSubmit}
+    className="bg-white p-4 rounded-lg border shadow-sm flex flex-col h-full"
+  >
+    <div className="flex items-start gap-1">
+      <div
+        className={`w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBgColor}`}
+      >
+        {icon}
+      </div>
+      <div className="flex-grow">
+        <h2 className="text-xl font-bold">{title}</h2>
+        <p className="mt-2 text-gray-600 text-sm min-h-[72px]">{description}</p>
+      </div>
+    </div>
+    {/* 이 카드의 내용물(form 등)이 이 자리에 렌더링됩니다. */}
+    <div className="mt-1 flex-grow">{children}</div>
+    <button
+      type="submit"
+      disabled={buttonColor.includes('gray')}
+      className={`w-full mt-6 py-2 rounded-lg text-white font-bold flex items-center justify-center gap-2 transition-colors ${buttonColor}`}
+    >
+      {buttonIcon}
+      {buttonText}
+    </button>
+  </form>
+);
+
+export default ActionCard;

--- a/src/components/join/GuestActionContainer.tsx
+++ b/src/components/join/GuestActionContainer.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { joinRoomAPI } from './api/roomService';
+import ActionCard from './ActionCard';
+import GuestForm from './GuestForm';
+import PlayIcon from '../../assets/icons/PlayIcon';
+import DocumentIcon from '../../assets/icons/DocumentIcon';
+
+const GuestActionContainer = () => {
+  const navigate = useNavigate();
+
+  // '참여자' 기능에 필요한 모든 상태를 여기서 관리합니다.
+  const [inviteCode, setInviteCode] = useState('');
+  const [userName, setUserName] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // '수업 참여하기' 버튼 클릭 시 실행될 함수
+  const handleJoinClass = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await joinRoomAPI(inviteCode);
+      // 성공 시, 서버에서 받은 방 정보(data)와 사용자가 입력한 이름(userName)을 가지고
+      // 실제 수업 페이지로 이동합니다.
+      navigate(`/room/${data.roomId}`, {
+        state: { roomInfo: data, myName: userName },
+      });
+    } catch (err) {
+      // API 호출 실패 시 에러 메시지를 상태에 저장하여 사용자에게 보여줍니다.
+      setError('참여에 실패했습니다. 초대코드를 확인해주세요.');
+      console.error(err);
+    } finally {
+      // API 호출이 성공하든 실패하든, 로딩 상태를 해제합니다.
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ActionCard
+      icon={<DocumentIcon className="w-6 h-6 text-white" />}
+      iconBgColor="bg-green-600"
+      title="참여자로 시작"
+      description="수업 ID로 실시간 코딩 세션에 참여하고 선생님의 도움을 받아 더 나은 코드를 작성하세요."
+      buttonIcon={<PlayIcon />}
+      buttonText={isLoading ? '참여 중...' : '수업 참여하기'}
+      buttonColor={
+        isLoading ? 'bg-gray-400' : 'bg-green-600 hover:bg-green-700'
+      }
+      onSubmit={handleJoinClass}
+    >
+      {/* 자식 컴포넌트에 상태와 상태 변경 함수를 props로 전달 */}
+      <GuestForm
+        inviteCode={inviteCode}
+        setInviteCode={setInviteCode}
+        userName={userName}
+        setUserName={setUserName}
+      />
+      {/* 에러가 있을 경우 메시지를 표시 */}
+      {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+    </ActionCard>
+  );
+};
+
+export default GuestActionContainer;

--- a/src/components/join/GuestForm.tsx
+++ b/src/components/join/GuestForm.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+// 이 폼이 부모로부터 받아야 할 props들을 정의합니다.
+interface GuestFormProps {
+  inviteCode: string;
+  userName: string;
+  setInviteCode: (value: string) => void;
+  setUserName: (value: string) => void;
+}
+
+const GuestForm: React.FC<GuestFormProps> = ({
+  inviteCode,
+  userName,
+  setInviteCode,
+  setUserName,
+}) => {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label
+          htmlFor="joinCode"
+          className="block text-sm font-medium text-gray-700"
+        >
+          수업참여코드
+        </label>
+        <input
+          id="joinCode"
+          type="text"
+          value={inviteCode}
+          onChange={(e) => setInviteCode(e.target.value)}
+          className="mt-1 w-full border rounded-md p-2 h-10"
+          placeholder="수업 ID를 입력하세요"
+          required
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="userName"
+          className="block text-sm font-medium text-gray-700"
+        >
+          이름
+        </label>
+        <input
+          id="userName"
+          type="text"
+          value={userName}
+          onChange={(e) => setUserName(e.target.value)}
+          className="mt-1 w-full border rounded-md p-2 h-10"
+          placeholder="이름을 입력하세요"
+          required
+        />
+      </div>
+    </div>
+  );
+};
+
+export default GuestForm;

--- a/src/components/join/HostActionContainer.tsx
+++ b/src/components/join/HostActionContainer.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createRoomAPI } from './api/roomService';
+import ActionCard from './ActionCard';
+import HostForm from './HostForm';
+import RocketIcon from '../../assets/icons/RocketIcon';
+import GraduationCapIcon from '../../assets/icons/GraduationCapIcon';
+
+const HostActionContainer = () => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [maxParticipants, setMaxParticipants] = useState(30);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCreateClass = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await createRoomAPI({ title, maxParticipants });
+      console.log('createRoomAPI result:', data);
+      navigate(`/room/${data.roomId}`);
+    } catch {
+      setError('수업 생성에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ActionCard
+      icon={<GraduationCapIcon />}
+      iconBgColor="bg-blue-600"
+      title="진행자로 시작"
+      description="새로운 수업을 생성하고 학생들의 성장을 도와주세요. 분석 도구로 구문 맞춤 지도가 가능합니다."
+      buttonIcon={<RocketIcon />}
+      buttonText={isLoading ? '생성 중...' : '수업 생성하기'}
+      buttonColor={isLoading ? 'bg-gray-400' : 'bg-blue-600 hover:bg-blue-700'}
+      onSubmit={handleCreateClass}
+    >
+      <HostForm
+        title={title}
+        setTitle={setTitle}
+        maxParticipants={maxParticipants}
+        setMaxParticipants={setMaxParticipants}
+      />
+      {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+    </ActionCard>
+  );
+};
+
+export default HostActionContainer;

--- a/src/components/join/HostForm.tsx
+++ b/src/components/join/HostForm.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface HostFormProps {
+  title: string;
+  maxParticipants: number;
+  setTitle: (v: string) => void;
+  setMaxParticipants: (v: number) => void;
+}
+
+const HostForm: React.FC<HostFormProps> = ({
+  title,
+  maxParticipants,
+  setTitle,
+  setMaxParticipants,
+}) => (
+  <div className="space-y-4">
+    <div>
+      <label
+        htmlFor="className"
+        className="block text-sm font-medium text-gray-700"
+      >
+        수업 이름
+      </label>
+      <input
+        id="className"
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="mt-1 w-full border rounded-md p-2 h-10"
+        required
+      />
+    </div>
+    <div>
+      <label
+        htmlFor="maxParticipants"
+        className="block text-sm font-medium text-gray-700"
+      >
+        최대 참여자수
+      </label>
+      <input
+        id="maxParticipants"
+        type="number"
+        value={maxParticipants}
+        onChange={(e) => setMaxParticipants(Number(e.target.value))}
+        className="mt-1 w-full border rounded-md p-2 h-10"
+        required
+      />
+    </div>
+  </div>
+);
+
+export default HostForm;

--- a/src/components/join/api/roomService.ts
+++ b/src/components/join/api/roomService.ts
@@ -1,0 +1,29 @@
+// '수업 생성' API 함수
+export const createRoomAPI = async ({
+  title,
+  maxParticipants,
+}: {
+  title: string;
+  maxParticipants: number;
+}) => {
+  // 실제 API 호출 예시 (POST)
+  const response = await fetch(`/api/room/create`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, maxParticipants }),
+  });
+  if (!response.ok) throw new Error('생성 실패');
+  return response.json();
+};
+
+// '수업 참여' API 함수
+export const joinRoomAPI = async (inviteCode: string) => {
+  // 실제 API 호출 예시 (POST)
+  const response = await fetch(`/api/room/join`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ inviteCode }),
+  });
+  if (!response.ok) throw new Error('참여 실패');
+  return response.json();
+};

--- a/src/pages/JoinPage.tsx
+++ b/src/pages/JoinPage.tsx
@@ -1,0 +1,22 @@
+import HostActionContainer from '../components/join/HostActionContainer';
+import GuestActionContainer from '../components/join/GuestActionContainer';
+import HeaderLogout from '../components/common/HeaderLogout';
+
+const JoinPage = () => {
+  return (
+    <div className="bg-slate-50 min-h-screen">
+      <HeaderLogout />
+      <div className="h-[70px] bg-slate-50"></div>
+      <div className="flex flex-col items-center mt-[50px]">
+        <div className="w-full max-w-4xl p-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+            <HostActionContainer />
+            <GuestActionContainer />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default JoinPage;


### PR DESCRIPTION
### 1. JoinPage (src/pages/JoinPage.tsx)

- **역할**:
- 수업에 "진행자" 또는 "참여자"로 입장할 수 있는 메인 진입 페이지
- 상단에 Header(로고+로그아웃), 중앙에 두 개의 카드(진행자/참여자) 배치
- 반응형 grid로 HostActionContainer, GuestActionContainer를 나란히 보여줌

---

**2. join 폴더 내 주요 컴포넌트**

### 2-1. HostActionContainer.tsx

- **역할**:
- "진행자"로 수업을 생성하는 카드
- 내부에 HostForm을 포함
- 수업 생성 API 호출, 입력값/로딩/에러 상태 관리
- **주요 UI**:
- 수업 이름, 최대 참여자수 입력
- "수업 생성하기" 버튼

### 2-2. GuestActionContainer.tsx

- **역할**:
- "참여자"로 수업에 입장하는 카드
- 내부에 GuestForm을 포함
- 수업 참여 API 호출, 입력값/로딩/에러 상태 관리
- **주요 UI**:
- 수업참여코드, 이름 입력
- "수업 참여하기" 버튼

### 2-3. HostForm.tsx

- **역할**:
- 진행자 카드에서 사용하는 입력 폼
- 수업 이름, 최대 참여자수 입력 필드 제공
- 입력값과 setter를 props로 받아 상태 관리

### 2-4. GuestForm.tsx

- **역할**:
- 참여자 카드에서 사용하는 입력 폼
- 수업참여코드, 이름 입력 필드 제공
- 입력값과 setter를 props로 받아 상태 관리

### 2-5. api/roomService.ts

- **역할**:
- 수업 생성(createRoomAPI), 수업 참여(joinRoomAPI) 등 API 함수 정의
- fetch로 백엔드와 통신

---

**데이터 및 동작 흐름**

1. **초기 화면**: JoinPage가 렌더링되면 진행자/참여자 카드가 나란히 보임
2. **진행자 카드**:
- HostForm에서 입력 → "수업 생성하기" 클릭 → createRoomAPI 호출 → 성공 시 이동/실패 시 에러 표시
1. **참여자 카드**:
- GuestForm에서 입력 → "수업 참여하기" 클릭 → joinRoomAPI 호출 → 성공 시 이동/실패 시 에러 표시
1. **상태 관리**: 각 카드에서 입력값, 로딩, 에러 상태를 useState로 관리**


![image](https://github.com/user-attachments/assets/e60b14d0-2e66-4e0b-b3c7-35fe0f0a2bd6)
