### PR TITLE
feat(#32): 아이콘 추가 및 학생 페이지 비율 조정, 결과 패널 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import ProblemImportForm from './components/teacher-class/ProblemImportForm';
 import ProblemCreateForm from './components/teacher-class/ProblemCreateForm';
+import StudentClassPage from './pages/StudentClassPage';
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/import" element={<ProblemImportForm />} />
         <Route path="/create" element={<ProblemCreateForm />} />
+        <Route path="/class" element={<StudentClassPage />} />
 
         {/* 다른 라우트 */}
       </Routes>

--- a/src/assets/bolt.svg
+++ b/src/assets/bolt.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#fff" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+</svg> 

--- a/src/assets/brain.svg
+++ b/src/assets/brain.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#94a3b8" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M19.002 10.222a7.502 7.502 0 10-14.004 0A7.502 7.502 0 0012 21a7.502 7.502 0 007.002-10.778zM12 21V10m0 0a.75.75 0 01.75-.75h.01a.75.75 0 01.75.75v.01a.75.75 0 01-.75.75h-.01a.75.75 0 01-.75-.75v-.01zM12 10a4.502 4.502 0 00-4.502 4.502" />
+</svg> 

--- a/src/assets/chart-bar.svg
+++ b/src/assets/chart-bar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#fff" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+</svg> 

--- a/src/assets/check-circle-green.svg
+++ b/src/assets/check-circle-green.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#4ade80" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg> 

--- a/src/assets/check-circle-slate.svg
+++ b/src/assets/check-circle-slate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#94a3b8" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg> 

--- a/src/assets/exclamation-triangle.svg
+++ b/src/assets/exclamation-triangle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#facc15" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+</svg> 

--- a/src/assets/lightbulb.svg
+++ b/src/assets/lightbulb.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#94a3b8" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707m12.728 0l-.707.707M12 21a9 9 0 110-18 9 9 0 010 18z" />
+</svg> 

--- a/src/components/student-class/AnalysisPanel.tsx
+++ b/src/components/student-class/AnalysisPanel.tsx
@@ -1,0 +1,204 @@
+/**
+ * @file AnalysisPanel.tsx
+ * @description
+ *    - 코드 분석 결과를 표시하는 오른쪽 사이드바 패널입니다.
+ *    - 모든 상태(로딩, 결과 데이터, 열림/닫힘)는 부모인 `StudentClassPage`에서 `props`로 제어합니다.
+ *
+ * @props
+ *    - `isLoading`: `true`이면 로딩 스피너를, `false`이면 결과를 보여줍니다.
+ *    - `result`: 서버로부터 받은 분석 결과 데이터 객체입니다.
+ *    - `onClose`: 패널의 닫기 버튼(×)을 눌렀을 때 호출될 함수입니다.
+ */
+import React from 'react';
+
+// --- Asset Imports --- //
+import chartBarIcon from '../../assets/chart-bar.svg';
+import boltIcon from '../../assets/bolt.svg';
+import brainIcon from '../../assets/brain.svg';
+import lightbulbIcon from '../../assets/lightbulb.svg';
+import checkCircleGreenIcon from '../../assets/check-circle-green.svg';
+import checkCircleSlateIcon from '../../assets/check-circle-slate.svg';
+import exclamationTriangleIcon from '../../assets/exclamation-triangle.svg';
+
+// --- Type Definitions --- //
+// 서버로부터 받을 분석 결과의 데이터 구조를 정의합니다.
+// TODO: 향후 실제 서버 API의 응답 형태와 다를 경우, 이 타입을 서버 명세에 맞게 수정해야 합니다.
+interface AnalysisResult {
+  progress: {
+    percentage: number;
+    tests: string;
+    time: string;
+  };
+  aiSuggestions: {
+    type: 'performance' | 'optimization' | 'best-practice';
+    title: string;
+    line?: number;
+  }[];
+  execution: {
+    problemTitle: string;
+    time: string;
+    memory: string;
+    status: 'success' | 'fail';
+  };
+  complexity: {
+    time: string;
+    space: string;
+    cyclomatic: number;
+    loc: number;
+  };
+  quality: {
+    efficiency: number;
+    readability: number;
+  };
+  performanceImprovements: string[];
+}
+
+// --- Props --- //
+// AnalysisPanel 컴포넌트가 부모(StudentClassPage)로부터 받는 props의 명세입니다.
+interface AnalysisPanelProps {
+  // 로딩 상태 여부. true이면 로딩 스피너를 보여줍니다.
+  isLoading: boolean;
+  // 분석 결과 데이터 객체. 데이터가 없으면 null입니다.
+  result: AnalysisResult | null;
+  // 패널 닫기 버튼(×)을 클릭했을 때 호출될 함수입니다.
+  onClose: () => void;
+}
+
+// --- Sub-components --- //
+// 정보를 담는 재사용 가능한 UI 카드 컴포넌트입니다.
+const InfoCard: React.FC<{ title: string; children: React.ReactNode; icon?: React.ReactNode }> = ({
+  title,
+  children,
+  icon,
+}) => (
+  <div className="bg-slate-800 rounded-lg p-4 mb-4">
+    <div className="flex items-center text-white font-bold mb-3">
+      {icon}
+      <h3 className="text-md">{title}</h3>
+    </div>
+    {children}
+  </div>
+);
+
+// 'result' prop으로 받은 데이터를 실제 UI로 렌더링하는 컴포넌트입니다.
+const AnalysisContent: React.FC<{ result: AnalysisResult }> = ({ result }) => (
+  <div>
+    {/* 실행 결과 카드 */}
+    <InfoCard
+      title={result.execution.problemTitle}
+      icon={<img src={chartBarIcon} alt="Chart" className="h-5 w-5 mr-2" />}
+    >
+      <div className="space-y-2 text-sm">
+        <div className="flex justify-between items-center">
+          <div className="flex items-center text-slate-300">
+            <img src={brainIcon} alt="Brain" className="h-5 w-5 mr-2" /> 실행 시간
+          </div>
+          <span className="text-white font-mono">{result.execution.time}</span>
+        </div>
+        <div className="flex justify-between items-center">
+          <div className="flex items-center text-slate-300">
+            <img src={lightbulbIcon} alt="Lightbulb" className="h-5 w-5 mr-2" /> 사용된 메모리양
+          </div>
+          <span className="text-white font-mono">{result.execution.memory}</span>
+        </div>
+        <div className="flex justify-between items-center">
+          <div className="flex items-center text-slate-300">
+            <img src={checkCircleSlateIcon} alt="Check" className="h-5 w-5 mr-2" /> 결과
+          </div>
+          <span
+            className={`font-semibold ${result.execution.status === 'success' ? 'text-green-400' : 'text-red-400'}`}
+          >
+            {result.execution.status.toUpperCase()}
+          </span>
+        </div>
+      </div>
+    </InfoCard>
+
+    {/* AI 개선 제안 카드 */}
+    <InfoCard
+      title="AI 개선 제안"
+      icon={<img src={boltIcon} alt="Bolt" className="h-5 w-5 mr-2" />}
+    >
+      {result.aiSuggestions.map((suggestion, index) => (
+        <div key={index} className="flex items-start p-3 rounded-md mb-2 bg-slate-700/50">
+          {suggestion.type === 'performance' && (
+            <img src={exclamationTriangleIcon} alt="Warning" className="h-6 w-6" />
+          )}
+          {suggestion.type === 'optimization' && (
+            <img src={boltIcon} alt="Optimization" className="h-6 w-6 text-blue-400" />
+          )}
+          {suggestion.type === 'best-practice' && (
+            <img src={checkCircleGreenIcon} alt="Best Practice" className="h-6 w-6" />
+          )}
+          <div className="ml-3">
+            <p className="text-white text-sm">{suggestion.title}</p>
+            {suggestion.line && (
+              <span className="text-xs text-slate-400">Line {suggestion.line}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </InfoCard>
+  </div>
+);
+
+// --- Main Component --- //
+// 코드 분석 결과를 표시하는 오른쪽 사이드바 패널입니다.
+// 모든 상태(로딩, 결과 데이터, 열림/닫힘)는 부모인 `StudentClassPage`에서 `props`로 제어합니다.
+export const AnalysisPanel: React.FC<AnalysisPanelProps> = ({ isLoading, result, onClose }) => {
+  // 로딩 스피너 컴포넌트
+  const Spinner = () => (
+    <svg
+      className="animate-spin h-8 w-8 text-blue-400"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      ></path>
+    </svg>
+  );
+
+  return (
+    <aside className="w-[380px] h-full bg-slate-900 border-l border-slate-700 flex flex-col transition-all duration-300">
+      <div className="flex justify-between items-center p-4 border-b border-slate-700">
+        <h2 className="text-xl font-bold text-white">분석 리포트</h2>
+        <button onClick={onClose} className="text-slate-400 hover:text-white text-2xl font-bold">
+          &times;
+        </button>
+      </div>
+
+      <div className="flex-grow p-4 overflow-y-auto">
+        {/* props 상태에 따라 조건부로 렌더링합니다 */}
+        {/* Case 1: 로딩 중 */}
+        {isLoading && (
+          <div className="h-full flex flex-col items-center justify-center">
+            <Spinner />
+            <p className="text-slate-400 mt-4">AI가 학생의 코드를 분석 중입니다...</p>
+          </div>
+        )}
+        {/* Case 2: 결과 데이터가 있을 때 */}
+        {!isLoading && result && <AnalysisContent result={result} />}
+        {/* Case 3: 결과 데이터가 없을 때 (초기 상태) */}
+        {!isLoading && !result && (
+          <div className="h-full flex items-center justify-center">
+            <p className="text-slate-400">제출된 코드가 없습니다.</p>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default AnalysisPanel;

--- a/src/components/student-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/student-class/EditorPanel/EditorPanel.tsx
@@ -15,8 +15,7 @@ interface EditorPanelProps {
 
 export const EditorPanel: React.FC<EditorPanelProps> = ({ code, onCodeChange }) => {
   return (
-    // 전체 패널은 flex-grow를 통해 남은 공간을 모두 차지합니다.
-    <div className="flex-grow bg-[#1e1e1e] flex flex-col">
+    <div className="bg-[#1e1e1e] flex flex-col h-full">
       {/* 에디터 상단에 위치한 정보 바 */}
       <div className="flex justify-between items-center bg-slate-900 px-4 py-2 text-sm text-slate-400 border-b border-slate-700">
         <span className="font-mono">&lt; &gt; solution.py</span>

--- a/src/components/student-class/ProblemPanel/ProblemDetailView.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemDetailView.tsx
@@ -66,16 +66,10 @@ const Tabs: React.FC<{
     `w-1/2 py-2 text-sm font-medium rounded-md flex items-center justify-center gap-2 transition-colors ${activeTab === tabName ? 'bg-slate-600 text-white' : 'text-slate-300 hover:bg-slate-700'}`;
   return (
     <div className="flex w-full bg-slate-800 p-1 rounded-lg">
-      <button
-        onClick={() => setActiveTab('problem')}
-        className={getTabClass('problem')}
-      >
+      <button onClick={() => setActiveTab('problem')} className={getTabClass('problem')}>
         문제
       </button>
-      <button
-        onClick={() => setActiveTab('test')}
-        className={getTabClass('test')}
-      >
+      <button onClick={() => setActiveTab('test')} className={getTabClass('test')}>
         테스트
       </button>
     </div>
@@ -87,9 +81,7 @@ const Tabs: React.FC<{
  * ProblemDescription: 문제 설명 컴포넌트
  * ======================================================================
  */
-const ProblemDescription: React.FC<{ problem: IProblemDetail }> = ({
-  problem,
-}) => (
+const ProblemDescription: React.FC<{ problem: IProblemDetail }> = ({ problem }) => (
   <div className="text-slate-300 space-y-6">
     <h2 className="text-2xl font-bold text-white">{problem.title}</h2>
     <p className="text-sm">{problem.description}</p>
@@ -121,9 +113,7 @@ const TestCaseItem: React.FC<{
     try {
       // 입력값 세팅 및 표준입력 리다이렉트
       pyodide.globals.set('test_input', testCase.input);
-      pyodide.runPython(
-        `import sys; from io import StringIO; sys.stdin = StringIO(test_input)`,
-      );
+      pyodide.runPython(`import sys; from io import StringIO; sys.stdin = StringIO(test_input)`);
       let capturedOutput = '';
       // 표준출력 캡처
       pyodide.setStdout({
@@ -147,26 +137,12 @@ const TestCaseItem: React.FC<{
   return (
     <div className="bg-slate-700 p-3 rounded-md">
       <div className="flex justify-between items-center mb-2">
-        <h4 className="font-semibold text-white text-sm">
-          Test Case {testCase.id}
-        </h4>
-        <button
-          onClick={handleRunTest}
-          disabled={isRunning}
-          className="disabled:opacity-50"
-        >
+        <h4 className="font-semibold text-white text-sm">Test Case {testCase.id}</h4>
+        <button onClick={handleRunTest} disabled={isRunning} className="disabled:opacity-50">
           {isRunning ? (
-            <img
-              src={playIcon}
-              alt="실행 중"
-              className="w-5 h-5 animate-spin"
-            />
+            <img src={playIcon} alt="실행 중" className="w-5 h-5 animate-spin" />
           ) : (
-            <img
-              src={playIcon}
-              alt="실행"
-              className="w-5 h-5 text-slate-400 hover:text-white"
-            />
+            <img src={playIcon} alt="실행" className="w-5 h-5 text-slate-400 hover:text-white" />
           )}
         </button>
       </div>
@@ -180,11 +156,7 @@ const TestCaseItem: React.FC<{
         {output && (
           <p>
             <strong>실제 출력:</strong> {output}
-            <span
-              className={
-                isCorrect ? 'text-green-400 ml-2' : 'text-red-400 ml-2'
-              }
-            >
+            <span className={isCorrect ? 'text-green-400 ml-2' : 'text-red-400 ml-2'}>
               {isCorrect ? '정답' : '오답'}
             </span>
           </p>
@@ -211,12 +183,7 @@ const TestCaseViewer: React.FC<{
 }> = ({ testCases, userCode, pyodide }) => (
   <div className="space-y-4">
     {testCases.map((tc) => (
-      <TestCaseItem
-        key={tc.id}
-        testCase={tc}
-        userCode={userCode}
-        pyodide={pyodide}
-      />
+      <TestCaseItem key={tc.id} testCase={tc} userCode={userCode} pyodide={pyodide} />
     ))}
   </div>
 );
@@ -234,41 +201,49 @@ export const ProblemDetailView: React.FC<ProblemDetailViewProps> = ({
   userCode,
   pyodide,
 }) => {
-  // 탭 상태 관리 ('problem': 문제 설명, 'test': 테스트케이스)
   const [activeTab, setActiveTab] = useState<'problem' | 'test'>('problem');
+
   return (
-    <div className="p-4 flex flex-col h-full">
-      <header className="flex-shrink-0">
-        <button
-          onClick={onBackToList}
-          className="text-sm text-slate-400 hover:text-white mb-4 flex items-center gap-1"
-        >
-          <img src={backIcon} alt="뒤로가기" className="w-4 h-4 inline-block" />{' '}
-          문제 목록으로
+    <div className="h-full flex flex-col p-4 bg-slate-800">
+      {/* 헤더: 뒤로가기 버튼과 제목 */}
+      <header className="flex items-center mb-4">
+        <button onClick={onBackToList} className="p-1 rounded-full hover:bg-slate-700 mr-3">
+          <img src={backIcon} alt="뒤로가기" className="w-6 h-6" />
         </button>
-        <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
+        <h1 className="text-lg font-bold truncate">{problem.title}</h1>
       </header>
-      <main className="flex-grow mt-6 overflow-y-auto pr-2">
+
+      {/* 탭 */}
+      <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
+
+      {/* 탭 컨텐츠 */}
+      <main className="flex-grow my-4 overflow-y-auto pr-2">
         {activeTab === 'problem' ? (
           <ProblemDescription problem={problem} />
         ) : (
-          <TestCaseViewer
-            testCases={testCases}
-            userCode={userCode}
-            pyodide={pyodide}
-          />
+          <TestCaseViewer testCases={testCases} userCode={userCode} pyodide={pyodide} />
         )}
       </main>
-      {activeTab === 'problem' && (
-        <footer className="flex-shrink-0 mt-6 pt-4 border-t border-slate-700">
-          <button
-            onClick={onSubmit}
-            className="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md"
+
+      {/* 푸터: 제출 버튼 */}
+      <footer className="mt-auto pt-4 border-t border-slate-700">
+        <button
+          onClick={onSubmit}
+          className="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-md hover:bg-blue-700 transition-colors duration-200 flex items-center justify-center gap-2"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
           >
-            제출하기
-          </button>
-        </footer>
-      )}
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+          채점 및 분석
+        </button>
+      </footer>
     </div>
   );
 };

--- a/src/components/student-class/ProblemPanel/ProblemListView.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemListView.tsx
@@ -70,16 +70,10 @@ export const ProblemListView: React.FC<{
   onSelectProblem: (id: string) => void;
 }> = ({ problems, onSelectProblem }) => (
   <div className="p-4 h-full flex flex-col">
-    <h2 className="text-xl font-semibold text-white mb-4 flex-shrink-0">
-      문제 선택
-    </h2>
+    <h2 className="text-xl font-semibold text-white mb-4 flex-shrink-0">문제 선택</h2>
     <div className="flex-grow overflow-y-auto pr-2 space-y-2">
       {problems.map((problem) => (
-        <ProblemListItem
-          key={problem.id}
-          problem={problem}
-          onSelect={onSelectProblem}
-        />
+        <ProblemListItem key={problem.id} problem={problem} onSelect={onSelectProblem} />
       ))}
     </div>
   </div>

--- a/src/components/student-class/ProblemPanel/ProblemPanel.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemPanel.tsx
@@ -76,14 +76,9 @@ interface ProblemPanelProps {
  * - userCode, onSubmit 등 props로 받아 하위로 전달
  * ======================================================================
  */
-export const ProblemPanel: React.FC<ProblemPanelProps> = ({
-  userCode,
-  onSubmit,
-}) => {
+export const ProblemPanel: React.FC<ProblemPanelProps> = ({ userCode, onSubmit }) => {
   // 현재 선택된 문제 id (null이면 목록 화면)
-  const [selectedProblemId, setSelectedProblemId] = useState<string | null>(
-    null,
-  );
+  const [selectedProblemId, setSelectedProblemId] = useState<string | null>(null);
   // pyodide 인스턴스 (파이썬 실행 환경)
   const [pyodide, setPyodide] = useState<Pyodide | null>(null);
   // pyodide 로딩 상태
@@ -118,7 +113,7 @@ export const ProblemPanel: React.FC<ProblemPanelProps> = ({
   );
 
   return (
-    <aside className="w-[360px] bg-slate-800 border-r border-slate-700">
+    <aside className="w-[360px] h-full bg-slate-800 border-r border-slate-700">
       {/* pyodide 로딩 중이면 로딩 메시지 */}
       {isPyodideLoading ? (
         <div className="flex items-center justify-center h-full text-slate-400">
@@ -136,10 +131,7 @@ export const ProblemPanel: React.FC<ProblemPanelProps> = ({
         />
       ) : (
         // 문제 목록 뷰
-        <ProblemListView
-          problems={mockProblems}
-          onSelectProblem={setSelectedProblemId}
-        />
+        <ProblemListView problems={mockProblems} onSelectProblem={setSelectedProblemId} />
       )}
     </aside>
   );

--- a/src/pages/StudentClassPage.tsx
+++ b/src/pages/StudentClassPage.tsx
@@ -2,30 +2,106 @@ import React, { useState } from 'react';
 import { Header } from '../components/student-class/Header';
 import ProblemPanel from '../components/student-class/ProblemPanel/ProblemPanel';
 import EditorPanel from '../components/student-class/EditorPanel/EditorPanel';
+import AnalysisPanel from '../components/student-class/AnalysisPanel';
+
+// 목업 데이터 정의
+const mockResult = {
+  progress: {
+    percentage: 75,
+    tests: '3/4',
+    time: '0.8s',
+  },
+  aiSuggestions: [
+    {
+      type: 'performance' as const,
+      title: '중첩 루프로 인한 성능 이슈 - Set 또는 HashMap 사용 권장',
+      line: 4,
+    },
+    {
+      type: 'optimization' as const,
+      title: 'ES6 filter/includes 메서드 활용으로 코드 간소화 가능',
+    },
+    { type: 'best-practice' as const, title: '변수명과 로직 구조가 명확합니다' },
+  ],
+  execution: {
+    problemTitle: '2257 Hello World',
+    time: '125ms',
+    memory: '13.4MB',
+    status: 'success' as const,
+  },
+  complexity: {
+    time: 'O(n²)',
+    space: 'O(n)',
+    cyclomatic: 3,
+    loc: 12,
+  },
+  quality: {
+    efficiency: 65,
+    readability: 80,
+  },
+  performanceImprovements: [
+    'Set 자료구조 활용으로 O(n) 달성',
+    'ES6 메서드로 코드 간소화',
+    '엣지 케이스 처리 추가',
+  ],
+};
 
 export const StudentClassPage: React.FC = () => {
   // 학생이 에디터에 작성하는 코드를 관리하는 상태
-  const [userCode, setUserCode] = useState<string>('# 여기에 코드를 입력하세요');
+  const [userCode, setUserCode] = useState<string>('def solution(a, b):\n  return a + b');
+  const [isAnalysisPanelOpen, setAnalysisPanelOpen] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [analysisResult, setAnalysisResult] = useState<any | null>(null);
 
   // 코드 변경 핸들러
   const handleCodeChange = (code: string | undefined) => {
     setUserCode(code || '');
   };
 
-  // 제출 핸들러 (임시)
+  // 제출 및 분석 핸들러
   const handleSubmit = () => {
-    console.log('제출된 코드:', userCode);
-    alert('코드가 제출되었습니다! (콘솔 확인)');
+    console.log('분석 시작. 제출된 코드:', userCode);
+    setAnalysisPanelOpen(true);
+    setIsAnalyzing(true);
+    setAnalysisResult(null);
+
+    // 실제로는 여기서 서버로 코드를 보내고 결과를 받아야 합니다.
+    // 지금은 2초 뒤에 목업 데이터를 표시하는 것으로 대체합니다.
+    setTimeout(() => {
+      setAnalysisResult(mockResult);
+      setIsAnalyzing(false);
+      console.log('분석 완료');
+    }, 2000);
+  };
+
+  const handlePanelClose = () => {
+    setAnalysisPanelOpen(false);
   };
 
   return (
     <div className="flex flex-col h-screen bg-slate-900 text-white">
       <Header classCode="실시간 코딩 테스트" />
       <main className="flex flex-grow overflow-hidden">
-        {/* 문제 패널 영역 (왼쪽) */}
-        <ProblemPanel userCode={userCode} onSubmit={handleSubmit} />
-        {/* Monaco Editor 영역 (오른쪽) */}
-        <EditorPanel code={userCode} onCodeChange={handleCodeChange} />
+        {/* 문제 패널 (너비 고정) */}
+        <div className="flex-shrink-0">
+          <ProblemPanel userCode={userCode} onSubmit={handleSubmit} />
+        </div>
+
+        {/* Monaco Editor 영역 (가변 너비) */}
+        <div className="flex-grow flex-shrink min-w-0">
+          <EditorPanel code={userCode} onCodeChange={handleCodeChange} />
+        </div>
+
+        {/* 분석 패널 (너비 고정, 조건부 렌더링) */}
+        {isAnalysisPanelOpen && (
+          <div className="flex-shrink-0">
+            <AnalysisPanel
+              isLoading={isAnalyzing}
+              result={analysisResult}
+              onClose={handlePanelClose}
+            />
+          </div>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
- 분석 패널에 필요한 아이콘 추가
- 학생이 코드를 제출하면 실행 시간, 메모리 사용량, AI 개선 제안 등을 보여주는 AnalysisPanel 컴포넌트
- 분석 패널(컴포넌트) 추가
- 학생 페이지 비율 고정 및 수정
- 분석 패널이 나타날 때 다른 패널이 찌그러지는 문제를 해결. 이제 문제 패널(좌)과 분석 패널(우)의 너비는 고정되고, 코드 에디터(중앙)의 너비만 유동적으로 조절

비율 조절 방법
메인 레이아웃에 flex를 사용
너비를 고정할 문제 패널과 분석 패널은 flex-shrink-0 클래스를 적용하여 너비가 줄어들지 않도록 막기
너비가 변해야 하는 에디터 패널에는 flex-grow 클래스를 적용하여 남은 공간을 모두 차지하게 설정. 이를 통해 세 패널의 너비 비율이 동적으로 유지된다.

ProblemPanel, EditorPanel, AnalysisPanel 세 컴포넌트의 루트(root) 요소에 h-full 클래스를 추가하여, 부모 컨테이너의 전체 높이를 채우도록 수정


![image](https://github.com/user-attachments/assets/f8d647a7-ec94-4608-b0b2-372681529f3a)
![image](https://github.com/user-attachments/assets/09bce1fb-e767-4c45-bbc3-367d99173e54)
