### PR TITLE
fix(#48): 회원가입 비밀번호 검증 추가(8자리 이상)

### DIFF
--- a/src/components/signup/SignupCard.tsx
+++ b/src/components/signup/SignupCard.tsx
@@ -23,6 +23,13 @@ const SignupCard: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // 비밀번호 길이 검증 (프론트 단)
+    if (formData.password.length < 8) {
+      setError('비밀번호는 최소 8자 이상이어야 합니다.');
+      return;
+    }
+
     if (formData.password !== formData.confirmPassword) {
       setError('비밀번호가 일치하지 않습니다.');
       return;


### PR DESCRIPTION
closes #48 

### 변경사항

src/component/signup/SignupCard.tsx 수정
```
 const handleSubmit = async (e: React.FormEvent) => {
    e.preventDefault();

    // 비밀번호 길이 검증 (프론트 단)
    if (formData.password.length < 8) {
      setError('비밀번호는 최소 8자 이상이어야 합니다.');
      return;
    }
```