### PR TITLE
fix(#82): pyodide 로딩 문제 해결 - 워커 사용

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,53 @@
     <link rel="icon" type="image/svg+xml" href="/coconut-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Coconut</title>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script>
+    <style>
+      /* --- Splash Screen Styles --- */
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: sans-serif;
+      }
+      #splash-screen {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        background-color: #0f172a; /* bg-slate-900 */
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        z-index: 9999;
+      }
+      .spinner {
+        width: 2rem; /* h-8 w-8 */
+        height: 2rem;
+        border: 4px solid rgba(59, 130, 246, 0.25); /* opacity-25 for blue-400 */
+        border-left-color: #3b82f6; /* text-blue-400 */
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+      #splash-screen p {
+        color: #94a3b8; /* text-slate-400 */
+        margin-top: 1rem; /* mt-4 */
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      #splash-screen.hidden {
+        display: none;
+      }
+    </style>
   </head>
   <body>
+    <div id="splash-screen">
+      <div class="spinner"></div>
+      <p>로딩중</p>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/public/pyodide-worker.js
+++ b/public/pyodide-worker.js
@@ -1,0 +1,132 @@
+// This is a web worker, so we can't use ES modules.
+// We use `importScripts` to load the Pyodide script.
+let pyodide;
+
+async function initializePyodide() {
+  self.postMessage({ type: 'status', data: 'Pyodide 로더 스크립트를 가져오는 중...' });
+  try {
+    importScripts('https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js');
+  } catch (e) {
+    self.postMessage({ type: 'error', data: `Pyodide 스크립트 로드 실패: ${e.message}` });
+    return; // 스크립트 로드 실패 시 함수 종료
+  }
+
+  if (typeof self.loadPyodide !== 'function') {
+    self.postMessage({
+      type: 'error',
+      data: 'loadPyodide 함수를 찾을 수 없습니다. 스크립트가 올바르게 로드되지 않았습니다.',
+    });
+    return;
+  }
+
+  self.postMessage({ type: 'status', data: 'Pyodide를 초기화하는 중입니다...' });
+  try {
+    pyodide = await self.loadPyodide();
+    self.postMessage({ type: 'status', data: 'Pyodide가 준비되었습니다.' });
+    self.postMessage({ type: 'ready' });
+  } catch (error) {
+    self.postMessage({
+      type: 'error',
+      data: `Pyodide 초기화 실패: ${error.message}\n${error.stack}`,
+    });
+  }
+}
+
+const pyodideReadyPromise = initializePyodide();
+
+/**
+ * Python traceback 문자열에서 가장 의미있는 마지막 에러 라인을 추출합니다.
+ * @param {string} fullTraceback - Pyodide가 반환한 전체 에러 메시지
+ * @returns {string} 간소화된 에러 메시지
+ */
+function simplifyTraceback(fullTraceback) {
+  if (typeof fullTraceback !== 'string') {
+    return String(fullTraceback);
+  }
+  const lines = fullTraceback.trim().split('\n');
+  const errorLineKeywords = [
+    'Error:',
+    'Exception:',
+    'NameError:',
+    'SyntaxError:',
+    'ValueError:',
+    'TypeError:',
+    'IndexError:',
+    'KeyError:',
+    'AttributeError:',
+  ];
+
+  // 뒤에서부터 순회하며 키워드가 포함된 첫 번째 라인을 찾습니다.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (errorLineKeywords.some((keyword) => line.includes(keyword))) {
+      return line;
+    }
+  }
+
+  // 적절한 라인을 찾지 못하면 마지막 라인을 반환
+  return lines[lines.length - 1];
+}
+
+/**
+ * Listens for messages from the main thread.
+ * When a message is received, it executes the Python code inside it.
+ */
+self.onmessage = async (event) => {
+  await pyodideReadyPromise;
+
+  if (!pyodide) {
+    self.postMessage({
+      type: 'error',
+      data: 'Pyodide가 초기화되지 않아 코드를 실행할 수 없습니다.',
+      id: event.data.id,
+    });
+    return;
+  }
+
+  const { code, id, ...context } = event.data;
+
+  try {
+    // 5초 타임아웃 Promise 생성
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('실행 시간 초과 (5초)')), 5000);
+    });
+
+    // 실제 코드 실행 Promise
+    const executePromise = (async () => {
+      for (const key of Object.keys(context)) {
+        pyodide.globals.set(key, context[key]);
+      }
+
+      // 매번 실행 시, 새로운 StringIO 객체로 입출력 상태를 완전히 리셋합니다.
+      pyodide.runPython(`
+        import sys, io
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        # test_input 변수가 존재하면, 그것을 표준 입력으로 설정합니다.
+        if 'test_input' in globals():
+          sys.stdin = io.StringIO(globals()['test_input'])
+      `);
+
+      await pyodide.runPythonAsync(code);
+
+      const stdout = pyodide.runPython('sys.stdout.getvalue()');
+      const stderr = pyodide.runPython('sys.stderr.getvalue()');
+
+      return { stdout, stderr };
+    })();
+
+    // 타임아웃과 코드 실행을 경쟁시킴
+    const { stdout, stderr } = await Promise.race([executePromise, timeoutPromise]);
+
+    if (stderr) {
+      const simplifiedError = simplifyTraceback(stderr);
+      self.postMessage({ type: 'error', data: simplifiedError, id });
+    } else {
+      self.postMessage({ type: 'result', data: stdout.trim(), id });
+    }
+  } catch (error) {
+    const simplifiedError = simplifyTraceback(error.message);
+    self.postMessage({ type: 'error', data: simplifiedError, id });
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,21 @@ function App() {
     initializeApp();
   }, [silentRefresh]);
 
+  // 로딩이 끝나면 스플래시 스크린을 숨깁니다.
+  useEffect(() => {
+    if (!isLoading) {
+      const splashScreen = document.getElementById('splash-screen');
+      if (splashScreen) {
+        // 이제 CSS 애니메이션이 없으므로, 즉시 DOM에서 제거합니다.
+        splashScreen.remove();
+      }
+    }
+  }, [isLoading]);
+
+  // React는 로딩 중 아무것도 렌더링하지 않습니다.
+  // 실제 로딩 표시는 index.html의 스플래시 스크린이 담당합니다.
   if (isLoading) {
-    return <div>Loading...</div>;
+    return null;
   }
 
   return (

--- a/src/components/student-class/ProblemPanel/ProblemDetailView.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemDetailView.tsx
@@ -1,10 +1,10 @@
 // src/components/student-class/ProblemPanel/ProblemDetailView.tsx
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useSubmissionStore } from '../../../store/submissionStore';
+import { useWorkerStore } from '../../../store/workerStore';
 import backIcon from '../../../assets/back.svg';
 import playIconUrl from '../../../assets/play.svg';
 import SvgIcon from '../../../components/common/SvgIcon';
-import type { Pyodide } from '../../../types/pyodide';
 import type { Problem } from '../../../store/teacherStore';
 
 // --- Props 타입 변경
@@ -13,10 +13,7 @@ interface StudentProblemDetailViewProps {
   onBackToList: () => void;
   onSubmit: () => void;
   userCode: string;
-  pyodide: Pyodide | null;
-  isPyodideLoading: boolean;
 }
-
 // --- 서브 컴포넌트들 그대로 사용 ---
 
 const Tabs: React.FC<{
@@ -63,91 +60,50 @@ const ProblemDescription: React.FC<{ problem: Problem }> = ({ problem }) => {
 const TestCaseItem: React.FC<{
   testCase: { id: number; input: string; expectedOutput: string };
   userCode: string;
-  pyodide: Pyodide | null;
-  isPyodideLoading: boolean;
-}> = ({ testCase, userCode, pyodide, isPyodideLoading }) => {
+}> = ({ testCase, userCode }) => {
+  const { runCode, output, error, isReady } = useWorkerStore();
   const [isRunning, setIsRunning] = useState(false);
-  const [output, setOutput] = useState('');
-  const [error, setError] = useState('');
-  const [hasRun, setHasRun] = useState(false);
+  const [testOutput, setTestOutput] = useState<string | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
 
-  const handleRunTest = async () => {
-    if (!pyodide || !userCode) return;
-    setIsRunning(true);
-    setOutput('');
-    setError('');
-    setHasRun(true);
-
-    try {
-      // Pyodide 상태 초기화
-      pyodide.setStdout({});
-      pyodide.runPython('import sys; sys.stdout.flush()');
-
-      // 타임아웃 추가 (5초)
-      const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('실행 시간 초과 (5초)')), 5000);
-      });
-
-      const executePromise = (async () => {
-        pyodide.globals.set('test_input', testCase.input);
-        pyodide.runPython(`import sys; from io import StringIO; sys.stdin = StringIO(test_input)`);
-        let captured = '';
-        pyodide.setStdout({ batched: (o: string) => (captured += o + '\n') });
-        await pyodide.runPythonAsync(userCode);
-        return captured.trim();
-      })();
-
-      const result = await Promise.race([executePromise, timeoutPromise]);
-      setOutput(result as string);
-    } catch (e: unknown) {
-      // 에러 메시지 간소화
-      let errorMessage = '';
-      if (e instanceof Error) {
-        if (e.message === '실행 시간 초과 (5초)') {
-          errorMessage = e.message;
-        } else {
-          // Python traceback에서 마지막 에러 메시지만 추출
-          const lines = e.message.split('\n');
-          const lastErrorLine = lines.find(
-            (line) =>
-              line.includes('Error:') ||
-              line.includes('Exception:') ||
-              line.trim().startsWith('NameError:') ||
-              line.trim().startsWith('SyntaxError:') ||
-              line.trim().startsWith('ValueError:') ||
-              line.trim().startsWith('TypeError:'),
-          );
-          errorMessage = lastErrorLine ? lastErrorLine.trim() : e.message;
-        }
-      } else {
-        errorMessage = String(e);
-      }
-      setError(errorMessage);
-    } finally {
-      // Pyodide 상태 정리
-      try {
-        pyodide.setStdout({});
-        pyodide.runPython('import sys; sys.stdout.flush(); sys.stdin = sys.__stdin__');
-      } catch {
-        // 정리 중 에러는 무시
-      }
+  useEffect(() => {
+    if (output && output.id === testCase.id) {
+      setTestOutput(output.data);
       setIsRunning(false);
     }
+  }, [output, testCase.id]);
+
+  useEffect(() => {
+    if (error && error.id === testCase.id) {
+      setTestError(error.data);
+      setIsRunning(false);
+    }
+  }, [error, testCase.id]);
+
+  const handleRunTest = () => {
+    if (!userCode.trim()) {
+      setTestError('코드를 입력한 후 실행해주세요.');
+      setTestOutput(null);
+      return;
+    }
+    if (!isReady) return;
+    setIsRunning(true);
+    setTestOutput(null);
+    setTestError(null);
+    runCode(userCode, { test_input: testCase.input }, testCase.id);
   };
 
-  const isCorrect = output.trim() === testCase.expectedOutput.trim();
+  const isCorrect = testOutput?.trim() === testCase.expectedOutput.trim();
 
   return (
     <div className="bg-slate-700 p-3 rounded-md">
       <div className="flex justify-between items-center mb-2">
         <h4 className="font-semibold text-white text-sm">Test Case {testCase.id}</h4>
         <div className="flex items-center gap-2">
-          {isPyodideLoading && (
-            <span className="text-xs text-slate-400">테스트 환경 로딩 중...</span>
-          )}
+          {!isReady && <span className="text-xs text-slate-400">테스트 환경 준비 중...</span>}
           <button
             onClick={handleRunTest}
-            disabled={isRunning || isPyodideLoading || !pyodide}
+            disabled={isRunning || !isReady}
             className="disabled:opacity-50"
           >
             {isRunning ? (
@@ -165,20 +121,22 @@ const TestCaseItem: React.FC<{
         <p>
           <strong>기대 출력:</strong> {testCase.expectedOutput}
         </p>
-        {hasRun && (
-          <p>
-            <strong>실제 출력:</strong> {output || '(출력 없음)'}
-            {output !== '' && (
-              <span className={`${isCorrect ? 'text-green-400' : 'text-red-400'} ml-2`}>
-                {isCorrect ? '정답' : '오답'}
-              </span>
+        {(testOutput !== null || testError !== null) && (
+          <>
+            <p>
+              <strong>실제 출력:</strong> {testOutput ?? '(출력 없음)'}
+              {testOutput !== null && !testError && (
+                <span className={`${isCorrect ? 'text-green-400' : 'text-red-400'} ml-2`}>
+                  {isCorrect ? '정답' : '오답'}
+                </span>
+              )}
+            </p>
+            {testError && (
+              <p className="text-red-400">
+                <strong>에러:</strong> {testError}
+              </p>
             )}
-          </p>
-        )}
-        {error && (
-          <p className="text-red-400">
-            <strong>에러:</strong> {error}
-          </p>
+          </>
         )}
       </div>
     </div>
@@ -188,18 +146,10 @@ const TestCaseItem: React.FC<{
 const TestCaseViewer: React.FC<{
   testCases: { id: number; input: string; expectedOutput: string }[];
   userCode: string;
-  pyodide: Pyodide | null;
-  isPyodideLoading: boolean;
-}> = ({ testCases, userCode, pyodide, isPyodideLoading }) => (
+}> = ({ testCases, userCode }) => (
   <div className="space-y-4">
     {testCases.map((tc) => (
-      <TestCaseItem
-        key={tc.id}
-        testCase={tc}
-        userCode={userCode}
-        pyodide={pyodide}
-        isPyodideLoading={isPyodideLoading}
-      />
+      <TestCaseItem key={tc.id} testCase={tc} userCode={userCode} />
     ))}
   </div>
 );
@@ -210,10 +160,9 @@ const StudentProblemDetailView: React.FC<StudentProblemDetailViewProps> = ({
   onBackToList,
   onSubmit,
   userCode,
-  pyodide,
-  isPyodideLoading,
 }) => {
   const { isSubmitting } = useSubmissionStore();
+  // workerError를 가져오던 부분을 삭제합니다.
   const [activeTab, setActiveTab] = useState<'problem' | 'test'>('problem');
 
   // 받아온 문제의 exampleTc를 id/input/expectedOutput 형태로 변환합니다.
@@ -235,7 +184,6 @@ const StudentProblemDetailView: React.FC<StudentProblemDetailViewProps> = ({
           })) || []
         );
       }
-
       return exampleTcData.map((tc, idx) => ({
         id: idx + 1,
         input: tc.input,
@@ -269,15 +217,11 @@ const StudentProblemDetailView: React.FC<StudentProblemDetailViewProps> = ({
       <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
 
       <main className="flex-grow my-4 overflow-y-auto pr-2">
+        {/* 불필요한 전역 에러 표시부 삭제 */}
         {activeTab === 'problem' ? (
           <ProblemDescription problem={problem} />
         ) : (
-          <TestCaseViewer
-            testCases={formatted}
-            userCode={userCode}
-            pyodide={pyodide}
-            isPyodideLoading={isPyodideLoading}
-          />
+          <TestCaseViewer testCases={formatted} userCode={userCode} />
         )}
       </main>
 
@@ -291,7 +235,7 @@ const StudentProblemDetailView: React.FC<StudentProblemDetailViewProps> = ({
             xmlns="http://www.w3.org/2000/svg"
             className="h-5 w-5"
             fill="none"
-            viewBox="0 0 24 24"
+            viewBox="0 0 24"
             stroke="currentColor"
             strokeWidth={2}
           >

--- a/src/components/student-class/ProblemPanel/ProblemPanel.tsx
+++ b/src/components/student-class/ProblemPanel/ProblemPanel.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import ProblemListView from './ProblemListView';
 import ProblemDetailView from './ProblemDetailView';
-import type { Pyodide } from '../../../types/pyodide';
 import { type Problem } from '../../../store/teacherStore';
 
 // 1. 컴포넌트가 받을 props 타입을 수정합니다. (problems 추가)
@@ -13,8 +12,6 @@ interface ProblemPanelProps {
   onSelectProblem: (problemId: number | null) => void;
 }
 
-// 2. 파일 내부에 있던 IProblem, ITestCase, mockProblems, mockTestCases는 모두 삭제합니다.
-
 export const ProblemPanel: React.FC<ProblemPanelProps> = ({
   problems,
   userCode,
@@ -22,34 +19,6 @@ export const ProblemPanel: React.FC<ProblemPanelProps> = ({
   selectedProblemId,
   onSelectProblem,
 }) => {
-  const [pyodide, setPyodide] = useState<Pyodide | null>(null);
-  const [isPyodideLoading, setIsPyodideLoading] = useState(false);
-
-  // Pyodide 로딩을 지연 로딩으로 변경 - 문제 상세보기에 들어갔을 때만 로딩
-  const initPyodide = async () => {
-    if (pyodide || isPyodideLoading) return; // 이미 로딩 중이거나 완료된 경우 리턴
-    setIsPyodideLoading(true);
-    try {
-      const pyodideInstance = await window.loadPyodide({
-        indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/',
-      });
-      setPyodide(pyodideInstance);
-    } catch (error) {
-      console.error('Pyodide 로드 실패:', error);
-    } finally {
-      setIsPyodideLoading(false);
-    }
-  };
-
-  // 문제 선택 시 Pyodide 로딩 시작
-  const handleSelectProblem = (problemId: number | null) => {
-    onSelectProblem(problemId);
-    if (problemId !== null) {
-      initPyodide(); // 문제 상세보기 진입 시 Pyodide 로딩 시작
-    }
-  };
-
-  // 3. 선택된 문제 객체를 mockProblems 대신 props로 받은 problems에서 찾습니다.
   const selectedProblem = useMemo(
     () => problems.find((p) => p.problemId === selectedProblemId) || null,
     [selectedProblemId, problems],
@@ -60,17 +29,15 @@ export const ProblemPanel: React.FC<ProblemPanelProps> = ({
       {selectedProblem ? (
         <ProblemDetailView
           problem={selectedProblem}
-          onBackToList={() => handleSelectProblem(null)}
+          onBackToList={() => onSelectProblem(null)}
           onSubmit={onSubmit}
           userCode={userCode}
-          pyodide={pyodide}
-          isPyodideLoading={isPyodideLoading}
         />
       ) : (
         <ProblemListView
           problems={problems}
           selectedProblemId={selectedProblemId}
-          onSelectProblem={handleSelectProblem}
+          onSelectProblem={onSelectProblem}
         />
       )}
     </aside>

--- a/src/pages/StudentClassPage.tsx
+++ b/src/pages/StudentClassPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useStudentStore } from '../store/studentStore';
 import { useSubmissionStore } from '../store/submissionStore';
 import { useAuthStore } from '../store/authStore';
+import { useWorkerStore } from '../store/workerStore';
 import { Header } from '../components/student-class/Header';
 import ProblemPanel from '../components/student-class/ProblemPanel/ProblemPanel';
 import EditorPanel from '../components/student-class/EditorPanel/EditorPanel';
@@ -10,6 +11,15 @@ import AnalysisPanel from '../components/student-class/AnalysisPanel';
 import socket from '../lib/socket';
 
 const StudentClassPage: React.FC = () => {
+  const { initialize, terminate } = useWorkerStore();
+
+  useEffect(() => {
+    initialize();
+    return () => {
+      terminate();
+    };
+  }, [initialize, terminate]);
+
   const { roomId } = useParams<{ roomId: string }>();
 
   const {
@@ -162,11 +172,8 @@ const StudentClassPage: React.FC = () => {
 
   if (isRoomLoading && !currentRoom) {
     return (
-      <div className="h-screen bg-slate-900 text-white flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white mx-auto mb-4"></div>
-          <p>수업 정보를 불러오는 중...</p>
-        </div>
+      <div className="h-screen bg-slate-900 flex flex-col items-center justify-center">
+        {/* 스피너와 문구를 모두 삭제하여 배경색만 남김 */}
       </div>
     );
   }

--- a/src/pages/TeacherClassPage.tsx
+++ b/src/pages/TeacherClassPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTeacherStore, type Student } from '../store/teacherStore';
 import { useSubmissionStore } from '../store/submissionStore';
+import { useWorkerStore } from '../store/workerStore'; // 1. workerStore import
 import socket from '../lib/socket';
 import TeacherHeader from '../components/teacher-class/Header';
 import TeacherProblemPanel from '../components/teacher-class/ProblemPanel/TeacherProblemPanel';
@@ -11,6 +12,16 @@ import StudentGridView from '../components/teacher-class/grid/StudentGridView';
 import { useAuthStore } from '../store/authStore';
 
 const TeacherClassPage: React.FC = () => {
+  const { initialize, terminate } = useWorkerStore(); // 2. 워커 함수 가져오기
+
+  // 3. 워커 생명주기 관리 useEffect 추가
+  useEffect(() => {
+    initialize();
+    return () => {
+      terminate();
+    };
+  }, [initialize, terminate]);
+
   const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
   const [isAnalysisPanelOpen, setAnalysisPanelOpen] = useState(false);
@@ -292,8 +303,8 @@ const TeacherClassPage: React.FC = () => {
 
   if (isRoomLoading && !currentRoom) {
     return (
-      <div className="h-screen bg-slate-900 text-white flex items-center justify-center">
-        Loading room...
+      <div className="h-screen bg-slate-900 flex items-center justify-center">
+        {/* 학생 페이지와 동일하게, 스피너와 문구를 모두 삭제하여 배경색만 남김 */}
       </div>
     );
   }

--- a/src/store/workerStore.ts
+++ b/src/store/workerStore.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+
+// 1. 결과/에러 상태에 고유 ID를 포함하는 타입 정의
+interface WorkerOutput {
+  id: number | null;
+  data: string | null;
+}
+
+interface WorkerState {
+  worker: Worker | null;
+  isReady: boolean;
+  isLoading: boolean;
+  status: string;
+  // 2. output과 error의 타입을 새로운 인터페이스로 변경
+  output: WorkerOutput;
+  error: WorkerOutput;
+  initialize: () => void;
+  // 3. runCode 함수 시그니처에 id 파라미터 추가
+  runCode: (code: string, context?: object, id?: number) => void;
+  terminate: () => void;
+}
+
+export const useWorkerStore = create<WorkerState>((set, get) => ({
+  worker: null,
+  isReady: false,
+  isLoading: true,
+  status: '워커를 초기화하고 있습니다...',
+  // 4. 초기 상태값 변경
+  output: { id: null, data: null },
+  error: { id: null, data: null },
+
+  initialize: () => {
+    // 이미 워커가 있으면 중복 실행 방지
+    if (get().worker) return;
+
+    // public 디렉토리에 있는 워커 스크립트를 로드합니다.
+    const worker = new Worker('/pyodide-worker.js');
+
+    worker.onmessage = (event) => {
+      // 5. 메시지 핸들러에서 id를 함께 처리
+      const { type, data, id } = event.data;
+      switch (type) {
+        case 'ready':
+          set({ isReady: true, isLoading: false, status: '준비 완료' });
+          break;
+        case 'status':
+          set({ status: data });
+          break;
+
+        case 'result':
+          set({ output: { id, data }, error: { id: null, data: null } });
+          break;
+        case 'error':
+          set({ error: { id, data }, output: { id: null, data: null } });
+          break;
+        default:
+          console.warn('워커로부터 알 수 없는 메시지를 받았습니다:', event.data);
+      }
+    };
+
+    worker.onerror = (e) => {
+      set({ error: { id: null, data: `웹 워커 에러: ${e.message}` }, isLoading: false });
+    };
+
+    set({ worker });
+  },
+
+  // 6. runCode 함수 구현 수정
+  runCode: (code: string, context: object = {}, id: number = 0) => {
+    const worker = get().worker;
+    if (worker && get().isReady) {
+      // 실행 시 이전 결과/에러 초기화
+      set({ output: { id: null, data: null }, error: { id: null, data: null } });
+      worker.postMessage({ code, id, ...context });
+    } else {
+      set({ error: { id, data: '워커가 준비되지 않았거나 초기화되지 않았습니다.' } });
+    }
+  },
+
+  terminate: () => {
+    get().worker?.terminate();
+    set({ worker: null, isReady: false, isLoading: true, status: '워커 종료됨' });
+  },
+}));


### PR DESCRIPTION
close #82 

## **1. 핵심 문제: Pyodide 로딩 및 실행으로 인한 UI 멈춤 (Blocking)**

- **문제점**:
    1. **반복 로딩**: 교사/학생 페이지의 문제 상세 보기에 들어갈 때마다, Pyodide매번 다운로드하
    2. **UI 멈춤**: Pyodide의 초기화 및 코드 실행 작업이 브라우저의 메인 스레드에서 직접 실행되어, 이 과정 동안 화면 전체가 멈푸는 현상이 발생
- **해결책: 웹 워커(Web Worker)**
    - 모든 무거운 작업을 별도의 백그라운드 스레드에서 처리하는 웹 워커를 도입하여, UI 멈춤 현상을 해결
    - 브라우저에 있는 기능 (사파리, 크롬 체크 완료)
    - 로딩이 메인 스레드를 점유하지 않아서 블락현상, 멈춤 안생김

## **2. 주요 해결 내용**

1. **웹 워커 스크립트 생성 (pyodide-worker.js)**
- **역할**: Pyodide의 로딩, 초기화, 코드 실행 등 모든 무거운 작업을 하는 스크립트를 새로 만들었음
- **기존 기능 이전:**
    - **타임아웃**: 코드 실행 시 **5초의 시간제한**, 무한 루프에 빠져도 멈추지 않도록 하는 기능
    - **에러 메시지 간소화**: 전체 에러 메시지(traceback) 대신, 간단한 오류코드로 변경
2. **웹 워커 중앙 관리소 생성 (workerStore.ts)**
- **역할**: 웹 워커를 생성하고, 컴포넌트와 워커 간의 통신 (Zustand)스토어를 만들었음
- UI 컴포넌트가 runCode() 함수만 호출하면 되도록, 코드 실행 과정을 단순화
- 여러 테스트 케이스를 동시에 실행해도 결과가 섞이지 않도록, **고유 ID 시스템**을 도입
3. **로딩 타이밍**
- Pyodide가 실제로 필요한 TeacherClassPage와 StudentClassPage에 **처음 진입했을 때만** 웹 워커가 생성되고 Pyodide가 로드된다. 페이지를 나가면 워크는 자동으로 삭제된다. (메모리 절약)
4. **UI 컴포넌트 리팩토링**
- 교사 및 학생용 ProblemDetailView.tsx 내부의 복잡한 Pyodide 실행 로직을 모두 제거
- 이제 각 컴포넌트는 workerStore에 코드 실행만 요청하고, 자신의 ID와 일치하는 결과만 받아서 화면에 표시하는 구조 (서버 채점 원리랑 비슷함. 채점 서버가 클라이언트에서 분리되어 있는 것.)
- "실행" 버튼 옆에 "테스트 환경 준비 중..." 텍스트와 실행 중 스피너가 표시되는 UI 추가
- 빈 코드 제출시 오류 코드 표시’
5. **추가 기능 전역 로딩 꾸밈**
- 흰색으로 로딩 뜨는 부분을 이쁘게 꾸밈. 스피너 돌아가고, 색상은 수업 페이지 색상과 동일
- 흰색 번쩍이는 현상은 없지만, 로딩이 보임, 롤백은 1초면 가능해서 이상하면 말씀 부탁드림

## 3. 결론

미니 채점 서버를 클라이언트에 만들어서 채점 요청을 보내는 방법으로 해결 함.

아마 로딩이 이제는 안보이고, UI block 현상이 안생길 듯. 아마도.