### PR TITLE
fix(#87): static analysis 문제 해결 - 워커 사용

### DIFF
--- a/src/analysis/staticAnalysis.ts
+++ b/src/analysis/staticAnalysis.ts
@@ -1,55 +1,64 @@
-// pyodide를 활용한 정적 분석 모듈
-// pyflakes를 pyodide 환경에 설치하고, 파이썬 코드를 분석하는 함수 제공
-
+import { useWorkerStore } from '../store/workerStore';
 import { extractFunctions, estimateComplexity } from './analysisUtils';
-
-let pyodide: unknown = null;
-
-export async function initPyodideAndPyflakes() {
-  if (pyodide) return pyodide;
-  pyodide = await (window as any).loadPyodide({
-    indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/',
-  });
-  await (pyodide as any).loadPackage('micropip');
-  await (pyodide as any).runPythonAsync(`
-import micropip
-await micropip.install('pyflakes')
-  `);
-  return pyodide;
-}
 
 export interface AnalysisResult {
   functions: Array<{ name: string; time: string; space: string; errors: string[] }>;
   global: { time: string; space: string; errors: string[] };
 }
 
+// 고유한 분석 요청 ID를 생성하기 위한 카운터
+let analysisIdCounter = 0;
+
 export async function analyzePythonCodeBlocks(code: string): Promise<AnalysisResult> {
-  await initPyodideAndPyflakes();
-  const codeBase64 = btoa(unescape(encodeURIComponent(code)));
-  const pyflakesResult: string = await (pyodide as any).runPythonAsync(`
-import base64
-from pyflakes.api import check
-from pyflakes.reporter import Reporter
-import io
-code = base64.b64decode("${codeBase64}").decode("utf-8")
-output = io.StringIO()
-reporter = Reporter(output, output)
-check(code, '<input>', reporter)
-output.getvalue()
-  `);
-  const { functions, global } = extractFunctions(code);
-  const funcResults = functions.map((fn) => {
-    const { time, space } = estimateComplexity(fn.code.join('\n'));
-    const errors = (pyflakesResult || '').split('\n').filter((l) => l.includes(fn.name));
-    return { name: fn.name, time, space, errors };
+  const { worker, runCode } = useWorkerStore.getState();
+
+  // 워커가 준비되지 않았으면 에러를 반환하거나 빈 결과를 반환할 수 있습니다.
+  if (!worker) {
+    console.error('정적 분석 실패: 웹 워커가 초기화되지 않았습니다.');
+    // 또는 기본 빈 결과를 반환
+    return { functions: [], global: { time: 'N/A', space: 'N/A', errors: [] } };
+  }
+
+  const currentAnalysisId = ++analysisIdCounter;
+
+  // 워커에 정적 분석 요청
+  runCode(code, { task: 'analyze' }, currentAnalysisId);
+
+  // 워커로부터 결과를 기다리는 Promise
+  return new Promise((resolve, reject) => {
+    const handleMessage = ({ data }: MessageEvent) => {
+      // 자신에게 온 메시지가 맞는지 ID로 확인
+      if (data.id !== currentAnalysisId) return;
+
+      if (data.type === 'analyze_result') {
+        const pyflakesResult = data.data;
+
+        // 기존의 분석 로직을 여기에 통합
+        const { functions, global } = extractFunctions(code);
+        const funcResults = functions.map((fn) => {
+          const { time, space } = estimateComplexity(fn.code.join('\n'));
+          const errors = (pyflakesResult || '').split('\n').filter((l) => l.includes(fn.name));
+          return { name: fn.name, time, space, errors };
+        });
+        const { time, space } = estimateComplexity(global);
+        const funcNames = functions.map((f) => f.name);
+        const globalErrors = (pyflakesResult || '')
+          .split('\n')
+          .filter((l) => funcNames.every((fn) => !l.includes(fn)) && l.trim() !== '');
+
+        // 리스너 제거 및 Promise 해결
+        worker.removeEventListener('message', handleMessage);
+        resolve({
+          functions: funcResults,
+          global: { time, space, errors: globalErrors },
+        });
+      } else if (data.type === 'error') {
+        // 리스너 제거 및 Promise 거부
+        worker.removeEventListener('message', handleMessage);
+        reject(new Error(data.data));
+      }
+    };
+
+    worker.addEventListener('message', handleMessage);
   });
-  const { time, space } = estimateComplexity(global);
-  const funcNames = functions.map((f) => f.name);
-  const globalErrors = (pyflakesResult || '')
-    .split('\n')
-    .filter((l) => funcNames.every((fn) => !l.includes(fn)) && l.trim() !== '');
-  return {
-    functions: funcResults,
-    global: { time, space, errors: globalErrors },
-  };
 }

--- a/src/components/analysis/StaticAnalysisReport.tsx
+++ b/src/components/analysis/StaticAnalysisReport.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { useStaticAnalysis } from '../../analysis/useStaticAnalysis';
-import type { AnalysisResult } from '../../analysis/staticAnalysis';
+// 존재하지 않는 아이콘들을, 실제로 있는 아이콘으로 대체합니다.
+import chartBarIcon from '../../assets/chart-bar.svg';
+import lightbulbIcon from '../../assets/lightbulb.svg';
+import checkCircleGreenIcon from '../../assets/check-circle-green.svg';
+import exclamationTriangleIcon from '../../assets/exclamation-triangle.svg';
 
 interface StaticAnalysisReportProps {
   code: string;
@@ -9,40 +13,79 @@ interface StaticAnalysisReportProps {
 const StaticAnalysisReport: React.FC<StaticAnalysisReportProps> = ({ code }) => {
   const { result, loading } = useStaticAnalysis(code);
 
+  if (loading) return <div className="p-4 text-slate-400">분석 중...</div>;
+  if (!result) return <div className="p-4 text-slate-400">아직 분석된 내용이 없습니다.</div>;
+
+  const { functions, global } = result;
+  const mainResult = functions.length > 0 ? functions[0] : global;
+  const pyflakesErrors = functions.length > 0 ? mainResult.errors : global.errors;
+
   return (
-    <div className="p-4 text-slate-200">
-      <h3 className="font-bold mb-2">정적 분석 결과</h3>
-      {loading ? (
-        <div className="text-slate-400">분석 중...</div>
-      ) : result ? (
-        <div>
-          {result.functions && result.functions.length > 0 && (
-            <div className="mb-4">
-              {result.functions.map((fn: AnalysisResult['functions'][number], idx: number) => (
-                <div key={fn.name + idx} className="mb-3 p-2 bg-slate-800 rounded">
-                  <div className="font-bold">[함수: {fn.name}]</div>
-                  <div>시간복잡도: {fn.time}</div>
-                  <div>공간복잡도: {fn.space}</div>
-                  <div>오류: {fn.errors && fn.errors.length ? fn.errors.join('\n') : '없음'}</div>
-                </div>
-              ))}
+    <div className="flex flex-col items-start gap-3 self-stretch w-full">
+      {/* 코드 품질 지표 카드 */}
+      <div className="flex flex-col items-center gap-3 pt-6 pb-6 px-1 relative self-stretch w-full bg-slate-700 rounded-lg border border-solid border-slate-600 shadow-sm">
+        <div className="flex w-full items-center relative px-4">
+          <img className="w-4 h-4 mr-2" alt="Frame" src={chartBarIcon} />
+          <h3 className="text-white font-bold">코드 품질 지표</h3>
+        </div>
+        <div className="flex flex-col items-start gap-3 pt-4 pb-2 px-6 relative self-stretch w-full border-t border-slate-600">
+          <div className="flex items-start justify-around gap-3 relative self-stretch w-full">
+            <div className="flex flex-col items-center flex-1">
+              <div className="text-slate-400 text-sm">시간 복잡도</div>
+              <div className="font-bold text-white text-sm">{mainResult.time}</div>
             </div>
-          )}
-          <div className="p-2 bg-slate-800 rounded">
-            <div className="font-bold">[글로벌 코드]</div>
-            <div>시간복잡도: {result.global?.time}</div>
-            <div>공간복잡도: {result.global?.space}</div>
-            <div>
-              오류:{' '}
-              {result.global?.errors && result.global.errors.length
-                ? result.global.errors.join('\n')
-                : '없음'}
+            <div className="flex flex-col items-center flex-1">
+              <div className="text-slate-400 text-sm">공간 복잡도</div>
+              <div className="font-bold text-white text-sm">{mainResult.space}</div>
             </div>
           </div>
+          <div className="w-full pt-3 border-t border-slate-600 mt-3">
+            <h4 className="text-sm font-semibold text-slate-300 mb-2">잠재적 오류:</h4>
+            {pyflakesErrors && pyflakesErrors.length > 0 ? (
+              pyflakesErrors.map((err, i) => (
+                <p key={i} className="text-yellow-400 text-xs font-mono break-words">
+                  - {err}
+                </p>
+              ))
+            ) : (
+              <p className="text-slate-500 text-sm">발견된 오류 없음</p>
+            )}
+          </div>
         </div>
-      ) : (
-        <div className="text-slate-400">문제가 발견되지 않았습니다.</div>
-      )}
+      </div>
+
+      {/* 실시간 힌트 카드 (목업) */}
+      <div className="flex flex-col items-center gap-3 pt-6 pb-6 px-1 relative self-stretch w-full bg-slate-700 rounded-lg border border-solid border-slate-600 shadow-sm">
+        <div className="flex w-full items-center relative px-4">
+          <img className="w-4 h-4 mr-2" alt="Hint" src={lightbulbIcon} />
+          <h3 className="text-white font-bold">실시간 힌트</h3>
+        </div>
+        <div className="flex flex-col items-start gap-3 pt-4 pb-2 px-6 relative self-stretch w-full border-t border-slate-600">
+          <div className="flex items-start p-3 relative self-stretch w-full bg-yellow-900/20 rounded-lg border border-solid border-yellow-700">
+            <img
+              className="w-4 h-4 mr-2 mt-1 shrink-0"
+              alt="Warning"
+              src={exclamationTriangleIcon}
+            />
+            <p className="flex-1 text-yellow-400 text-sm">
+              중첩 루프로 인한 성능 이슈가 감지되었습니다
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 개선 제안 카드 (목업) */}
+      <div className="flex flex-col items-start gap-3 p-6 relative self-stretch w-full bg-slate-700 rounded-lg border border-solid border-slate-600 shadow-sm">
+        <div className="flex items-center relative self-stretch w-full">
+          <img className="w-4 h-4 mr-2" alt="Suggestion" src={checkCircleGreenIcon} />
+          <h3 className="text-white font-bold">개선 제안</h3>
+        </div>
+        <div className="flex flex-col items-start gap-2 relative self-stretch w-full pt-4 border-t border-slate-600">
+          <p className="text-slate-300 text-sm">
+            · HashMap을 사용하면 O(n) 시간 복잡도로 개선 가능
+          </p>
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# fix: 웹 워커 도입으로 인해 정적 분석 기능 fix

#### **1. 문제점**

UI 멈춤을 해결하기 위해 도입된 웹 워커(Web Worker) Pyodide 실행 환경을 메인 스레드에서 백그라운드 스레드로 이전.

이 구조 변경으로 인해, 기존에 메인 스레드에서 직접 `window.loadPyodide()`를 호출하여 사용하던 **실시간 정적 분석(`StaticAnalysisReport`) 기능**이 `loadPyodide` 함수를 찾지 못해 안되는 문제 발생.

#### **2. 해결 방법**
Python 관련 작업은 웹 워커로 옮긴김에 웹 워커에서 처리하는게 좋은 방안이기 때문에 정적 분석 기능을 웹 워커 기반으로 fix

#### **3. 상세 변경 내용**

*   **웹 워커 기능 확장 (`pyodide-worker.js`)**:
    *   웹 워커가 초기화될 때, 정적 분석에 필요한 `pyflakes` 패키지를 함께 설치
    *   메인 스레드로부터 `task: 'analyze'` 요청을 받을 경우, `pyflakes`를 이용해 코드를 분석하고 그 결과를 반환하는 새로운 작업 분기를 추가

*   **정적 분석 로직 리팩토링 (`staticAnalysis.ts`)**:
    *   기존에 메인 스레드에서 직접 Pyodide를 로드하고 실행하던 `initPyodideAndPyflakes` 함수와 관련 코드를 삭제
    *   `analyzePythonCodeBlocks` 함수가 이제 웹 워커에 `task: 'analyze'` 메시지를 보내고, `analyze_result` 응답을 비동기적으로 기다렸다가 결과를 파싱하여 반환

*   **UI 컴포넌트 변경(`StaticAnalysisReport.tsx`)**:
    *   피그마 디자인 기반으로 정적 분석 결과 UI를 변경
    *   AI 분석 패널도 카드만 추가 (목업 데이터)


