### PR TITLE
fix(#90): 그림판 색상 선택 위치 변경 및 버그 픽스

### DIFF
--- a/src/components/common/SvgOverlay.tsx
+++ b/src/components/common/SvgOverlay.tsx
@@ -128,13 +128,13 @@ const SvgOverlay: React.FC<SVGOverlayProps> = ({
           )}
         </g>
       </svg>
-      {/* 색상 선택 & 지우기 버튼: readOnly가 아니고 show일 때만 */}
+      {/* 색상 선택 & 지우기 버튼: readOnly가 아니고 show일 때만 (우상단) */}
       {!readOnly && setColor && (
         <div
           style={{
             position: 'absolute',
             top: 10,
-            left: 10,
+            right: 10,
             display: 'flex',
             gap: 8,
             pointerEvents: 'auto',

--- a/src/components/common/SvgOverlay.tsx
+++ b/src/components/common/SvgOverlay.tsx
@@ -1,0 +1,165 @@
+import React, { useRef, useState } from 'react';
+
+export const COLORS = ['#ff0000', '#00ff00', '#0000ff', '#000000', '#ffffff'];
+
+interface SVGOverlayProps {
+  lines: Array<{ points: [number, number][]; color: string }>;
+  setLines: (lines: Array<{ points: [number, number][]; color: string }>) => void;
+  addLine?: (line: { points: [number, number][]; color: string }) => void;
+  color?: string;
+  setColor?: React.Dispatch<React.SetStateAction<string>>;
+  readOnly?: boolean;
+  show: boolean;
+  onClear?: () => void;
+  scrollTop?: number;
+  editorRef?: React.RefObject<any>;
+}
+
+const SvgOverlay: React.FC<SVGOverlayProps> = ({
+  lines,
+  setLines,
+  addLine,
+  color = COLORS[0],
+  setColor = () => {},
+  readOnly = false,
+  show,
+  onClear,
+  scrollTop = 0,
+  editorRef,
+}) => {
+  const [drawing, setDrawing] = useState(false);
+  const [currentLine, setCurrentLine] = useState<{
+    points: [number, number][];
+    color: string;
+  } | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  if (!show) return null;
+
+  // 마우스 이벤트 핸들러
+  const handleMouseDown = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (readOnly) return;
+    setDrawing(true);
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top + scrollTop;
+    setCurrentLine({ points: [[x, y]], color });
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (readOnly) return;
+    if (!drawing || !currentLine) return;
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top + scrollTop;
+    setCurrentLine({
+      ...currentLine,
+      points: [...currentLine.points, [x, y]],
+    });
+  };
+
+  const handleMouseUp = () => {
+    if (readOnly) return;
+    if (drawing && currentLine) {
+      if (addLine) {
+        addLine(currentLine);
+      } else {
+        setLines([...lines, currentLine]);
+      }
+      setTimeout(() => setCurrentLine(null), 0);
+    }
+    setDrawing(false);
+  };
+
+  const handleClear = () => {
+    setLines([]);
+    setCurrentLine(null);
+    if (onClear) onClear();
+  };
+
+  // 드로잉 중일 때만 pointerEvents: 'auto', 그 외에는 'none'
+  const svgPointerEvents = readOnly ? 'none' : 'auto';
+
+  // 휠 이벤트를 Monaco Editor에 강제로 전달
+  const handleWheel = (e: React.WheelEvent<SVGSVGElement>) => {
+    if (editorRef?.current) {
+      const curr = editorRef.current.getScrollTop();
+      editorRef.current.setScrollTop(curr + e.deltaY);
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <>
+      <svg
+        ref={svgRef}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          pointerEvents: svgPointerEvents,
+          zIndex: 10,
+        }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+      >
+        <g transform={`translate(0, -${scrollTop})`}>
+          {[...lines, currentLine].map((line, idx) =>
+            line ? (
+              <polyline
+                key={idx}
+                points={line.points.map(([x, y]) => `${x},${y}`).join(' ')}
+                fill="none"
+                stroke={line.color}
+                strokeWidth={3}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            ) : null,
+          )}
+        </g>
+      </svg>
+      {/* 색상 선택 & 지우기 버튼: readOnly가 아니고 show일 때만 */}
+      {!readOnly && setColor && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 10,
+            left: 10,
+            display: 'flex',
+            gap: 8,
+            pointerEvents: 'auto',
+            zIndex: 20,
+          }}
+        >
+          {COLORS.map((c) => (
+            <button
+              key={c}
+              onClick={() => setColor(c)}
+              style={{
+                background: c,
+                width: 24,
+                height: 24,
+                border: color === c ? '2px solid #fff' : '1px solid #ccc',
+              }}
+            />
+          ))}
+          <button onClick={handleClear} style={{ padding: '0 8px', height: 24 }}>
+            지우기
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SvgOverlay;

--- a/src/components/student-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/student-class/EditorPanel/EditorPanel.tsx
@@ -1,9 +1,15 @@
 /**
  * 학생 페이지의 코드 에디터 UI를 담당하는 컴포넌트입니다.
  */
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import Editor from '@monaco-editor/react';
 import usersIcon from '../../../assets/usersIcon.svg';
+import SvgOverlay from '../../common/SvgOverlay';
+
+interface SVGLine {
+  points: [number, number][];
+  color: string;
+}
 
 // EditorPanel이 부모로부터 받을 props 타입을 정의합니다.
 // 에디터 내용이 변경될 때 호출될 함수 (상위 컴포넌트의 상태를 업데이트)
@@ -13,6 +19,13 @@ interface EditorPanelProps {
   onCodeChange: (value: string | undefined) => void;
   studentName?: string; // 추가: 학생 이름
   disabled?: boolean; // 추가: 에디터 비활성화
+  roomId?: string; // 추가: 방 ID
+  userId?: string; // 추가: 사용자 ID
+  role?: 'teacher' | 'student'; // 추가: 사용자 역할
+  svgLines: SVGLine[]; // SVG 라인 데이터
+  onAddSVGLine: (line: SVGLine) => void; // SVG 라인 추가 핸들러
+  onClearSVGLines: () => void; // SVG 라인 클리어 핸들러
+  onSetSVGLines: (lines: SVGLine[]) => void; // SVG 라인 설정 핸들러
 }
 
 export const EditorPanel: React.FC<EditorPanelProps> = ({
@@ -20,7 +33,39 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
   onCodeChange,
   studentName,
   disabled,
+  roomId,
+  userId,
+  role,
+  svgLines,
+  onAddSVGLine,
+  onClearSVGLines,
+  onSetSVGLines,
 }) => {
+  // SVGOverlay 관련 상태
+  const editorRef = useRef<any>(null);
+  const [color, setColor] = useState('#ff0000');
+  // 그림판 on/off 상태
+  const [showOverlay, setShowOverlay] = useState(false);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  // Monaco Editor 스크롤 동기화
+  const handleEditorMount = (editor: any) => {
+    editorRef.current = editor;
+    setScrollTop(editor.getScrollTop());
+    editor.onDidScrollChange(() => {
+      setScrollTop(editor.getScrollTop());
+    });
+  };
+
+  // SVGOverlay에서 사용할 핸들러들
+  const handleSetLines = (newLines: Array<{ points: [number, number][]; color: string }>) => {
+    onSetSVGLines(newLines);
+  };
+
+  const handleClear = () => {
+    onClearSVGLines();
+  };
+
   return (
     <div className="bg-[#1e1e1e] flex flex-col h-full">
       {/* 에디터 상단에 위치한 정보 바 */}
@@ -31,11 +76,18 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
             <img src={usersIcon} alt="참가자 수" className="w-4 h-4" />
             <span>{studentName ? studentName : '학생'}</span>
           </div>
+          {/* 그림판 토글 버튼: 학생은 읽기 전용이지만 보기 위해 필요 */}
+          <button
+            className={`px-3 py-1 rounded transition ${showOverlay ? 'bg-blue-600 text-white' : 'bg-slate-700 text-slate-200 hover:bg-slate-600'}`}
+            onClick={() => setShowOverlay((v) => !v)}
+          >
+            {showOverlay ? '그림판 숨기기' : '그림판 보기'}
+          </button>
         </div>
       </div>
 
       {/* Monaco Editor가 렌더링되는 영역 */}
-      <div className="flex-grow">
+      <div className="flex-grow relative">
         <Editor
           height="100%"
           language="python"
@@ -57,6 +109,19 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
             padding: { top: 16 },
             readOnly: disabled, // 추가: 비활성화 시 읽기 전용
           }}
+          onMount={handleEditorMount}
+        />
+        <SvgOverlay
+          lines={svgLines}
+          setLines={handleSetLines}
+          addLine={onAddSVGLine}
+          color={color}
+          setColor={setColor}
+          readOnly={role !== 'teacher'}
+          show={showOverlay}
+          onClear={handleClear}
+          editorRef={editorRef}
+          scrollTop={scrollTop}
         />
       </div>
     </div>

--- a/src/components/teacher-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/teacher-class/EditorPanel/EditorPanel.tsx
@@ -78,15 +78,18 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
                 : `${studentName || selectedStudentId} 에디터`}
             </span>
           </div>
-          {/* 그림판 토글 버튼: 항상 보이게 */}
-          <button
-            className={`px-3 py-1 rounded transition ${showOverlay ? 'bg-green-600 text-white' : 'bg-slate-700 text-slate-200 hover:bg-slate-600'}`}
-            onClick={() => setShowOverlay((v) => !v)}
-          >
-            {showOverlay ? '그림판 끄기' : '그림판 켜기'}
-          </button>
+          <div className="flex items-center gap-2">
+            {/* 그림판 토글 버튼: 항상 보이게 */}
+            <button
+              className={`px-3 py-1 rounded transition ${showOverlay ? 'bg-green-600 text-white' : 'bg-slate-700 text-slate-200 hover:bg-slate-600'}`}
+              onClick={() => setShowOverlay((v) => !v)}
+            >
+              {showOverlay ? '그림판 끄기' : '그림판 켜기'}
+            </button>
+          </div>
         </div>
       </div>
+
       {/* Monaco Editor + SvgOverlay */}
       <div className="flex-grow relative">
         {isConnecting ? (

--- a/src/components/teacher-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/teacher-class/EditorPanel/EditorPanel.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import Editor from '@monaco-editor/react';
 import usersIcon from '../../../assets/usersIcon.svg';
+import SvgOverlay from '../../common/SvgOverlay';
+import { useRef, useState, useEffect } from 'react';
+
+interface SVGLine {
+  points: [number, number][];
+  color: string;
+}
 
 interface TeacherEditorPanelProps {
   code: string;
@@ -9,6 +16,13 @@ interface TeacherEditorPanelProps {
   studentName?: string; // 추가: 학생 이름
   onClickReturnToTeacher?: () => void; // 추가: 내 코드로 전환 버튼 클릭 핸들러
   isConnecting?: boolean; // 추가: 학생 연결 중 상태
+  roomId?: string; // 추가: 방 ID
+  userId?: string; // 추가: 사용자 ID
+  role?: 'teacher' | 'student'; // 추가: 사용자 역할
+  svgLines: SVGLine[]; // SVG 라인 데이터
+  onAddSVGLine: (line: SVGLine) => void; // SVG 라인 추가 핸들러
+  onClearSVGLines: () => void; // SVG 라인 클리어 핸들러
+  onSetSVGLines: (lines: SVGLine[]) => void; // SVG 라인 설정 핸들러
 }
 
 const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
@@ -18,7 +32,38 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
   studentName,
   onClickReturnToTeacher,
   isConnecting = false,
+  roomId,
+  userId,
+  role,
+  svgLines,
+  onAddSVGLine,
+  onClearSVGLines,
+  onSetSVGLines,
 }) => {
+  const editorRef = useRef<any>(null);
+  const [color, setColor] = useState('#ff0000');
+  // 그림판 on/off 상태
+  const [showOverlay, setShowOverlay] = useState(false);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  // Monaco Editor 스크롤 동기화
+  const handleEditorMount = (editor: any) => {
+    editorRef.current = editor;
+    setScrollTop(editor.getScrollTop());
+    editor.onDidScrollChange(() => {
+      setScrollTop(editor.getScrollTop());
+    });
+  };
+
+  // SVGOverlay에서 사용할 핸들러들
+  const handleSetLines = (newLines: Array<{ points: [number, number][]; color: string }>) => {
+    onSetSVGLines(newLines);
+  };
+
+  const handleClear = () => {
+    onClearSVGLines();
+  };
+
   return (
     <div className="bg-[#1e1e1e] flex flex-col h-full">
       {/* 에디터 상단 정보 바 (선생님/학생 모드 표시) */}
@@ -33,10 +78,17 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
                 : `${studentName || selectedStudentId} 에디터`}
             </span>
           </div>
+          {/* 그림판 토글 버튼: 항상 보이게 */}
+          <button
+            className={`px-3 py-1 rounded transition ${showOverlay ? 'bg-green-600 text-white' : 'bg-slate-700 text-slate-200 hover:bg-slate-600'}`}
+            onClick={() => setShowOverlay((v) => !v)}
+          >
+            {showOverlay ? '그림판 끄기' : '그림판 켜기'}
+          </button>
         </div>
       </div>
-      {/* Monaco Editor */}
-      <div className="flex-grow">
+      {/* Monaco Editor + SvgOverlay */}
+      <div className="flex-grow relative">
         {isConnecting ? (
           <div className="flex items-center justify-center h-full text-slate-400">
             <div className="text-center">
@@ -46,19 +98,34 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
             </div>
           </div>
         ) : (
-          <Editor
-            height="100%"
-            language="python"
-            theme="vs-dark"
-            value={code}
-            onChange={onCodeChange}
-            options={{
-              fontSize: 14,
-              minimap: { enabled: false },
-              scrollBeyondLastLine: false,
-              padding: { top: 16 },
-            }}
-          />
+          <>
+            <Editor
+              height="100%"
+              language="python"
+              theme="vs-dark"
+              value={code}
+              onChange={onCodeChange}
+              options={{
+                fontSize: 14,
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                padding: { top: 16 },
+              }}
+              onMount={handleEditorMount}
+            />
+            <SvgOverlay
+              lines={svgLines}
+              setLines={handleSetLines}
+              addLine={onAddSVGLine}
+              color={color}
+              setColor={setColor}
+              readOnly={!showOverlay ? true : false}
+              show={showOverlay}
+              onClear={handleClear}
+              editorRef={editorRef}
+              scrollTop={scrollTop}
+            />
+          </>
         )}
       </div>
     </div>

--- a/src/pages/StudentClassPage.tsx
+++ b/src/pages/StudentClassPage.tsx
@@ -135,6 +135,12 @@ const StudentClassPage: React.FC = () => {
         setSvgLines([]);
       });
 
+      // 소켓 연결 해제 시 그림 자동 지우기
+      socket.on('disconnect', () => {
+        console.log('[Student] 소켓 연결 해제 - 그림 자동 지우기');
+        setSvgLines([]);
+      });
+
       return () => {
         socket.off('room:joined');
         socket.off('room:full');
@@ -144,6 +150,7 @@ const StudentClassPage: React.FC = () => {
         socket.off('collab:ended');
         socket.off('svgData');
         socket.off('svgCleared');
+        socket.off('disconnect');
       };
     }
   }, [roomId, inviteCode, myId, myName]);
@@ -237,7 +244,7 @@ const StudentClassPage: React.FC = () => {
           <EditorPanel
             code={userCode}
             onCodeChange={handleCodeChange}
-            studentName={user?.name}
+            studentName={myName}
             disabled={isCollabLoading}
             roomId={roomId}
             userId={user?.id ? String(user.id) : undefined}

--- a/src/pages/TeacherClassPage.tsx
+++ b/src/pages/TeacherClassPage.tsx
@@ -40,6 +40,7 @@ const TeacherClassPage: React.FC = () => {
   const [, forceUpdate] = useState(0);
 
   const [svgLines, setSvgLines] = useState<SVGLine[]>([]);
+  const [studentSvgLines, setStudentSvgLines] = useState<Map<number, SVGLine[]>>(new Map());
 
   const {
     currentRoom,
@@ -104,6 +105,11 @@ const TeacherClassPage: React.FC = () => {
       setCollaborationId(null);
       setSelectedStudentId(null);
       setIsConnectingToStudent(false); // 협업 종료 시 연결 상태 초기화
+      // 협업 종료 시 현재 학생의 그림 데이터 저장
+      if (selectedStudentId) {
+        setStudentSvgLines((prev) => new Map(prev.set(selectedStudentId, svgLines)));
+        setSvgLines([]); // 현재 그림 초기화
+      }
     });
 
     // SVG 관련 이벤트 리스너
@@ -117,6 +123,12 @@ const TeacherClassPage: React.FC = () => {
       setSvgLines([]);
     });
 
+    // 소켓 연결 해제 시 그림 자동 지우기
+    socket.on('disconnect', () => {
+      console.log('[Teacher] 소켓 연결 해제 - 그림 자동 지우기');
+      setSvgLines([]);
+    });
+
     return () => {
       socket.off('room:joined');
       socket.off('room:full');
@@ -127,6 +139,7 @@ const TeacherClassPage: React.FC = () => {
       socket.off('collab:ended');
       socket.off('svgData');
       socket.off('svgCleared');
+      socket.off('disconnect');
       // void만 리턴 (아무것도 리턴하지 않음)
     };
   }, []); // ← 빈 배열!
@@ -257,6 +270,8 @@ const TeacherClassPage: React.FC = () => {
       // 그리드로 돌아갈 때 현재 상태를 기억
       if (selectedStudentId !== null) {
         setPreviousEditorState('student');
+        // 현재 학생의 그림 데이터 저장
+        setStudentSvgLines((prev) => new Map(prev.set(selectedStudentId, svgLines)));
       } else {
         setPreviousEditorState('teacher');
       }
@@ -267,10 +282,12 @@ const TeacherClassPage: React.FC = () => {
         socket.emit('collab:end', { collaborationId });
         setCollaborationId(null);
         setSelectedStudentId(null);
+        setSvgLines([]); // 그림 초기화
       }
     } else if (newMode === 'editor') {
       // 무조건 선생님 에디터로 전환
       setSelectedStudentId(null);
+      setSvgLines([]); // 그림 초기화
     }
     setMode(newMode);
   };
@@ -291,6 +308,10 @@ const TeacherClassPage: React.FC = () => {
       setSelectedStudentId(studentId);
       setMode('editor');
       setIsConnectingToStudent(true); // 학생 연결 시작
+
+      // 4) 해당 학생의 저장된 그림 데이터 불러오기
+      const savedSvgLines = studentSvgLines.get(studentId) || [];
+      setSvgLines(savedSvgLines);
 
       if (socket.connected) {
         console.log('collab:start emit (immediate)', {
@@ -315,10 +336,15 @@ const TeacherClassPage: React.FC = () => {
     if (collaborationId) {
       socket.emit('collab:end', { collaborationId });
     }
+    // 현재 학생의 그림 데이터 저장
+    if (selectedStudentId) {
+      setStudentSvgLines((prev) => new Map(prev.set(selectedStudentId, svgLines)));
+    }
     setSelectedStudentId(null);
     setCollaborationId(null);
     setIsConnectingToStudent(false); // 연결 상태 초기화
     setPreviousEditorState('teacher'); // 선생님 에디터 상태로 기록
+    setSvgLines([]); // 그림 초기화
   };
 
   // SVG 관련 핸들러 함수들


### PR DESCRIPTION
그림판 색상 선택 위치를 좌상단에서 우상단으로 옮겨서 직관적으로 만들었습니다.

그리고 학생이 여러 명일 때 그림이 겹치는 버그가 있었는데 선생님이 나갈 때 그림을 저장이 되고 학생 별로 다시 불러올 수 있게 만들었습니다. 지금은 새로고침을 하면 그림이 날라가게 됩니다. 크게 문제가 안된다고 생각하지만 문제가 있다고 생각하면 말씀 주십쇼.