### PR TITLE
fix(#96): 학생에디터 말풍선 남는 문제 해결 및 중복 소켓리스너 삭제

### DIFF
--- a/src/pages/StudentClassPage.tsx
+++ b/src/pages/StudentClassPage.tsx
@@ -128,6 +128,7 @@ const StudentClassPage: React.FC = () => {
       socket.on('collab:ended', () => {
         setCollaborationId(null);
         collabIdRef.current = null;
+        setOtherCursor(null);
       });
       socket.on('cursor:update', ({ lineNumber, column }) => {
         setOtherCursor({ lineNumber, column });

--- a/src/pages/TeacherClassPage.tsx
+++ b/src/pages/TeacherClassPage.tsx
@@ -131,21 +131,6 @@ const TeacherClassPage: React.FC = () => {
       setSvgLines([]);
     });
 
-    // SVG 관련 이벤트 리스너
-    socket.on('svgData', (data: { lines: SVGLine[] }) => {
-      console.log('[Teacher] svgData 수신', data.lines?.length || 0, '개 라인');
-      setSvgLines(data.lines || []);
-    });
-
-    socket.on('svgCleared', () => {
-      console.log('[Teacher] svgCleared 수신');
-      setSvgLines([]);
-    });
-
-    socket.on('cursor:update', ({ lineNumber, column }) => {
-      setOtherCursor({ lineNumber, column });
-    });
-
     socket.on('cursor:update', ({ lineNumber, column }) => {
       setOtherCursor({ lineNumber, column });
     });


### PR DESCRIPTION
closes #96 

socket.on('collab:ended', () => {
        setCollaborationId(null);
        collabIdRef.current = null;
        setOtherCursor(null); 
      });
StudentClassPage.tsx 에 3번째줄 setOtherCursor(null); 추가
* 선생이 학생과의 협업 세션에서 퇴장 했을 때 학생에디터 화면에서 선생 말풍선을 삭제

teacherClassPage 의 중복 소켓 리스너 삭제
