### PR TITLE
fix(#92): 웹소켓 연결 문제 해결

### DIFF
--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -8,7 +8,7 @@ server {
     
     # 모든 API 요청을 /api/v1/ prefix를 추가하여 백엔드로 프록시
     # 정규식 ^/(auth|room|db)/를 사용해서 이 세 가지 경로 패턴에 대해서만 /api/v1 prefix를 추가하고, $uri 변수를 사용해서 원본 경로를 그대로 유지
-    location ~ ^/(auth|room|rooms|db)/ {
+    location ~ ^/(auth|rooms|db)/ {
         proxy_pass http://backend/api/v1$uri;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -7,7 +7,7 @@ server {
     server_name localhost;
     
     # 모든 API 요청을 /api/v1/ prefix를 추가하여 백엔드로 프록시
-    # 정규식 ^/(auth|rooms|db)/를 사용해서 이 세 가지 경로 패턴에 대해서만 /api/v1 prefix를 추가하고, $uri 변수를 사용해서 원본 경로를 그대로 유지
+    # 정규식 ^/(auth|room|db)/를 사용해서 이 세 가지 경로 패턴에 대해서만 /api/v1 prefix를 추가하고, $uri 변수를 사용해서 원본 경로를 그대로 유지
     location ~ ^/(auth|rooms|db)/ {
         proxy_pass http://backend/api/v1$uri;
         proxy_set_header Host $host;
@@ -33,7 +33,7 @@ server {
 
     # websocket의 초기 http handshake를 백엔드로 전달
     location /socket.io/ {
-    proxy_pass http://backend;
+    proxy_pass http://backend$uri;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;        # WebSocket 업그레이드
     proxy_set_header Connection "upgrade";         # 연결 업그레이드

--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -8,7 +8,7 @@ server {
     
     # 모든 API 요청을 /api/v1/ prefix를 추가하여 백엔드로 프록시
     # 정규식 ^/(auth|room|db)/를 사용해서 이 세 가지 경로 패턴에 대해서만 /api/v1 prefix를 추가하고, $uri 변수를 사용해서 원본 경로를 그대로 유지
-    location ~ ^/(auth|room|db)/ {
+    location ~ ^/(auth|room|rooms|db)/ {
         proxy_pass http://backend/api/v1$uri;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -30,6 +30,16 @@ server {
         proxy_send_timeout 30s;
         proxy_read_timeout 30s;
     }
+
+    # websocket의 초기 http handshake를 백엔드로 전달
+    location /socket.io/ {
+    proxy_pass http://backend:3001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;        # WebSocket 업그레이드
+    proxy_set_header Connection "upgrade";         # 연결 업그레이드
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+}
     
     # 프론트엔드 정적 파일
     location / {

--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -33,7 +33,7 @@ server {
 
     # websocket의 초기 http handshake를 백엔드로 전달
     location /socket.io/ {
-    proxy_pass http://backend$uri;
+    proxy_pass http://backend$request_uri;         # 쿼리 스트링까지 포함해서 백엔드에 요청
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;        # WebSocket 업그레이드
     proxy_set_header Connection "upgrade";         # 연결 업그레이드

--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -8,7 +8,7 @@ server {
     
     # 모든 API 요청을 /api/v1/ prefix를 추가하여 백엔드로 프록시
     # 정규식 ^/(auth|room|db)/를 사용해서 이 세 가지 경로 패턴에 대해서만 /api/v1 prefix를 추가하고, $uri 변수를 사용해서 원본 경로를 그대로 유지
-    location ~ ^/(auth|rooms|db)/ {
+    location ~ ^/(auth|room|db)/ {
         proxy_pass http://backend/api/v1$uri;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/coconut.conf.template
+++ b/nginx/coconut.conf.template
@@ -33,12 +33,13 @@ server {
 
     # websocket의 초기 http handshake를 백엔드로 전달
     location /socket.io/ {
-    proxy_pass http://backend:3001;
+    proxy_pass http://backend;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;        # WebSocket 업그레이드
     proxy_set_header Connection "upgrade";         # 연결 업그레이드
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
     
     # 프론트엔드 정적 파일

--- a/src/components/common/HeaderLogout.tsx
+++ b/src/components/common/HeaderLogout.tsx
@@ -1,7 +1,7 @@
 //src/components/commoc/HeaderLogout.tsx
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { logout } from './logoutApi';
+// import { logout } from './logoutApi';
 
 const HeaderLogout: React.FC = () => {
   const navigate = useNavigate();
@@ -9,11 +9,11 @@ const HeaderLogout: React.FC = () => {
   const handleLogout = async () => {
     const accessToken = localStorage.getItem('accessToken');
     if (!accessToken) return;
-    try {
-      await logout(accessToken);
-    } catch (e) {
-      // 에러 무시 (네트워크 등)
-    }
+    // try {
+    //   await logout(accessToken);
+    // } catch (e) {
+    //   // 에러 무시 (네트워크 등)
+    // }
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
     navigate('/login');

--- a/src/store/studentStore.ts
+++ b/src/store/studentStore.ts
@@ -40,7 +40,7 @@ export const useStudentStore = create<StudentState>()(
         try {
           const response = await getRoomDetailsAPI(roomId);
           const problems = response.data.problems || [];
-          const newProblemIds = problems.map((p) => p.problemId);
+          const newProblemIds = problems.map((p: Problem) => p.problemId);
 
           // 기존 코드를 유지하면서 새로운 문제에 대해서만 초기 코드 설정
           set((state) => {


### PR DESCRIPTION
# 404 Error
원인 :
에디터 접속 
➡️ 프론트엔드 서버로 소켓 연결 요청이 전송됨 (Http request)
➡️ 프론트엔드 서버에 설치된 nginx가 받음 
➡️ nginx는 해당 요청을 백엔드 서버로 보내야 하는데 프론트엔드 서버에서 처리하려고 시도
➡️ 해당 경로에 맞는 static file이 없음
➡️ 404 에러
<img width="371" height="461" alt="image" src="https://github.com/user-attachments/assets/719bc104-fb1f-4830-bcf5-1e9e1af8512b" />
<img width="2904" height="1574" alt="image" src="https://github.com/user-attachments/assets/5cdec610-e0f8-46d0-8c3c-794cacbea3e5" />

해결 : 
nginx config에 소켓 연결 요청이 오면 백엔드 도메인으로 보내주는 로직을 추가
[참고](https://github.com/Making-my-own-weapon/Coconut-Frontend/compare/dev...deploy-test?expand=1#diff-2669bfb4529a4de0b01b7b77b0911c59218a3ef3c3bb1cdf1c2e7a5ede34f91c)
```
    # websocket의 초기 http handshake를 백엔드로 전달
    location /socket.io/ {
    proxy_pass http://backend$request_uri;         # 쿼리 스트링까지 포함해서 백엔드에 요청
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;        # WebSocket 업그레이드
    proxy_set_header Connection "upgrade";         # 연결 업그레이드
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```
# 400 Error
원인 :
nginx가 백엔드 서버에 소켓 연결 요청할 때 /socket.io/ 뒤에 오는 쿼리 스트링을 전달하지 않음
➡️ client가 잘못된 uri를 요청
➡️ 400 에러
<img width="377" height="465" alt="image" src="https://github.com/user-attachments/assets/d858df02-ce3a-40e7-8342-9fc6dd50ef96" />

해결 :
nginx config의 proxy_pass를 $uri 에서 $request_uri로 변경
```
http://backend$request_uri;
```


