### PR TITLE
feat(#124): 선생님 리포트 페이지에 학생 리포트 버튼 눌렀을 때 나오는 학생 카드 개발

### DIFF
--- a/src/components/report/CardReportStudent.tsx
+++ b/src/components/report/CardReportStudent.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 export interface CardReportStudentProps {
   studentName: string;
   correctAnswers: number;
+  totalProblems: number;
   className?: string;
 }
 
 const CardReportStudent: React.FC<CardReportStudentProps> = ({
   studentName,
   correctAnswers,
+  totalProblems,
   className = '',
 }) => {
   return (
@@ -54,10 +56,10 @@ const CardReportStudent: React.FC<CardReportStudentProps> = ({
 
       {/* Correct answers number */}
       <div
-        className="absolute left-[191px] top-[406px] w-[24px] h-[40px] text-white text-4xl font-normal leading-10"
+        className="absolute left-[191px] top-[406px] w-[60px] h-[40px] text-white text-4xl font-normal leading-10"
         style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
       >
-        {correctAnswers}
+        {correctAnswers}/{totalProblems}
       </div>
     </div>
   );

--- a/src/components/report/StudentReportView.tsx
+++ b/src/components/report/StudentReportView.tsx
@@ -18,51 +18,10 @@ interface StudentData {
 
 interface StudentReportViewProps {
   studentResults: StudentData[];
+  totalProblems: number;
 }
 
-// 👇 submissions 배열에 가짜 데이터를 추가합니다.
-const mockStudents: StudentData[] = [
-  {
-    studentName: '김대원',
-    correctAnswers: 8,
-    submissions: [
-      { id: 1, submissionNumber: 1, status: 'passed', memory: '128KB', executionTime: '0.5ms' },
-      { id: 2, submissionNumber: 2, status: 'passed', memory: '132KB', executionTime: '0.4ms' },
-    ],
-  },
-  {
-    studentName: '정소영',
-    correctAnswers: 6,
-    submissions: [
-      { id: 1, submissionNumber: 1, status: 'passed', memory: '128KB', executionTime: '0.5ms' },
-      { id: 2, submissionNumber: 2, status: 'passed', memory: '132KB', executionTime: '0.4ms' },
-    ],
-  },
-  {
-    studentName: '박지성',
-    correctAnswers: 8,
-    submissions: [
-      { id: 1, submissionNumber: 1, status: 'passed', memory: '128KB', executionTime: '0.5ms' },
-      { id: 2, submissionNumber: 2, status: 'passed', memory: '132KB', executionTime: '0.4ms' },
-    ],
-  },
-  {
-    studentName: '배재준',
-    correctAnswers: 10,
-    submissions: [
-      {
-        id: 3,
-        submissionNumber: 1,
-        status: 'runtime_error',
-        memory: '256KB',
-        executionTime: '1.2ms',
-      },
-      { id: 4, submissionNumber: 2, status: 'passed', memory: '260KB', executionTime: '1.1ms' },
-    ],
-  },
-];
-
-const StudentReportView: React.FC<StudentReportViewProps> = ({ studentResults }) => {
+const StudentReportView: React.FC<StudentReportViewProps> = ({ studentResults, totalProblems }) => {
   const [selectedStudent, setSelectedStudent] = useState<StudentData | null>(null);
 
   // 👇 함수를 컴포넌트 안으로 옮겨서 props에 접근할 수 있게 합니다.
@@ -84,9 +43,9 @@ const StudentReportView: React.FC<StudentReportViewProps> = ({ studentResults })
               <BoardReportStudent
                 studentName={selectedStudent.studentName}
                 correctAnswers={selectedStudent.correctAnswers}
-                students={mockStudents.map((s) => s.studentName)}
+                students={studentResults.map((s) => s.studentName)}
                 onStudentSelect={(name) => {
-                  const student = mockStudents.find((s) => s.studentName === name);
+                  const student = studentResults.find((s) => s.studentName === name);
                   if (student) setSelectedStudent(student);
                 }}
               />
@@ -102,8 +61,9 @@ const StudentReportView: React.FC<StudentReportViewProps> = ({ studentResults })
         </div>
       ) : (
         // --- 학생 선택 전 (목록 보기) ---
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {mockStudents.map((student) => (
+        // 학생 목록 가운데 정렬
+        <div className="flex flex-wrap justify-center gap-8">
+          {studentResults.map((student) => (
             <div
               key={student.studentName}
               onClick={() => setSelectedStudent(student)}
@@ -112,6 +72,7 @@ const StudentReportView: React.FC<StudentReportViewProps> = ({ studentResults })
               <CardReportStudent
                 studentName={student.studentName}
                 correctAnswers={student.correctAnswers}
+                totalProblems={totalProblems}
               />
             </div>
           ))}

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -154,12 +154,25 @@ const ReportPage: React.FC = () => {
     </>
   );
 
-  const studentMockData = [
-    { studentName: '김대원', correctAnswers: 8, submissions: [] },
-    { studentName: '배재준', correctAnswers: 10, submissions: [] },
-    { studentName: '정소영', correctAnswers: 5, submissions: [] },
-    { studentName: '주의재', correctAnswers: 9, submissions: [] },
-  ];
+  // DB에서 받은 리포트 데이터만 사용 (스토어 의존성 제거)
+  const studentData = useMemo(() => {
+    if (!reportData) return [];
+
+    const studentSubmissions = reportData.studentSubmissions || [];
+    const totalProblems = reportData.totalProblems || 1;
+
+    // studentSubmissions에서 직접 학생 데이터 생성 (백엔드에서 이미 학생만 필터링됨)
+    return studentSubmissions.map((submission) => {
+      // 정답률을 정답 개수로 변환 (전체 문제 수 * 정답률 / 100)
+      const correctAnswers = Math.round((submission.successRate * totalProblems) / 100);
+
+      return {
+        studentName: submission.name,
+        correctAnswers: correctAnswers,
+        submissions: [],
+      };
+    });
+  }, [reportData]);
 
   return (
     <ReportLayout actions={actionButtons} tabs={tabs} roomTitle={reportData?.roomTitle}>
@@ -175,7 +188,12 @@ const ReportPage: React.FC = () => {
       )}
       {activeView === 'problem' && <ProblemReportView />}
 
-      {activeView === 'student' && <StudentReportView studentResults={studentMockData} />}
+      {activeView === 'student' && (
+        <StudentReportView
+          studentResults={studentData}
+          totalProblems={reportData?.totalProblems || 0}
+        />
+      )}
     </ReportLayout>
   );
 };


### PR DESCRIPTION
1. 실제 학생들이 카드에 연동되게 수정했습니다.
2. 정답은 방에 할당된 문제와 학생이 맞힌 문제 갯수를 볼 수 있게 작업했습니다.
3. 학생 카드가 줄어들어도 왼쪽에 정렬되는 문제가 있었는데 카드 갯수에 상관없이 가운데 정렬되게 수정했습니다.