### PR TITLE
feat(#132): 음성채팅 p2p-mesh -> sfu(opnevidu)로 전환

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "esbuild": "^0.25.6",
         "lucide-react": "^0.525.0",
         "monaco-editor": "^0.43.0",
+        "openvidu-browser": "^2.31.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
@@ -4164,6 +4165,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4377,6 +4387,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/freeice": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/freeice/-/freeice-2.2.2.tgz",
+      "integrity": "sha512-XNoIxDHufqPIBSLpp4IrFPnoc+hv/0RwdOGhIoggIDC2ZKf5r6OoixbeoFJSmZOAq2aYiEUArhuQ8zVVrM5C4w==",
+      "license": "MIT",
+      "dependencies": {
+        "normalice": "^1.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -4605,6 +4624,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hark": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hark/-/hark-1.2.3.tgz",
+      "integrity": "sha512-u68vz9SCa38ESiFJSDjqK8XbXqWzyot7Cj6Y2b6jk2NJ+II3MY2dIrLMg/kjtIAun4Y1DHF/20hfx4rq1G5GMg==",
+      "license": "MIT",
+      "dependencies": {
+        "wildemitter": "^1.2.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5301,6 +5329,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsnlog": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/jsnlog/-/jsnlog-2.30.0.tgz",
+      "integrity": "sha512-o3ROQVkhek+dkc7/9TXlB4TNtxUpYsRLOBJHZYk3Vy0B5zRBmfv9tyr56PrjcgEXuy06ARgfLTANY0+ImhzzGA==",
+      "license": "MIT"
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5859,6 +5893,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -6026,6 +6072,12 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
+    "node_modules/normalice": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalice/-/normalice-1.0.1.tgz",
+      "integrity": "sha512-wF2/tv9q/K8S+RqCgll5yC6z/zcXNr+rEHfGIw8A6D58vjfJo+kp749MI6cAHv72LE7nwv92Qi6tZhIeMOOJpg==",
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6178,6 +6230,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openvidu-browser": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/openvidu-browser/-/openvidu-browser-2.31.0.tgz",
+      "integrity": "sha512-68d3t+jI6SDcfQFzSB1lj9nEhcJc87+iqZTpR66s2j26/JlPNNzZ3yft1UCjhQFVogfqHIgvYiTCGkw+755LRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "events": "3.3.0",
+        "freeice": "2.2.2",
+        "hark": "1.2.3",
+        "inherits": "2.0.4",
+        "jsnlog": "2.30.0",
+        "mime": "3.0.0",
+        "platform": "1.3.6",
+        "semver": "7.6.2",
+        "uuid": "9.0.1",
+        "wolfy87-eventemitter": "5.2.9"
+      }
+    },
+    "node_modules/openvidu-browser/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/optionator": {
@@ -6396,6 +6478,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -8123,6 +8211,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
@@ -8351,6 +8452,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildemitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wildemitter/-/wildemitter-1.2.1.tgz",
+      "integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw=="
+    },
+    "node_modules/wolfy87-eventemitter": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
+      "integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==",
+      "license": "Unlicense"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "esbuild": "^0.25.6",
     "lucide-react": "^0.525.0",
     "monaco-editor": "^0.43.0",
+    "openvidu-browser": "^2.31.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",

--- a/src/api/openviduApi.ts
+++ b/src/api/openviduApi.ts
@@ -1,0 +1,11 @@
+import { apiClient } from './client';
+
+// 세션 생성
+export const createOpenViduSession = (customSessionId: string) =>
+  apiClient.post('/openvidu/sessions', { customSessionId });
+
+// 토큰 발급 (role 정보 포함)
+export const createOpenViduToken = (
+  sessionId: string,
+  role: 'PUBLISHER' | 'SUBSCRIBER' = 'PUBLISHER',
+) => apiClient.post(`/openvidu/sessions/${sessionId}/connections`, { role });

--- a/src/components/common/VoiceChatModal.tsx
+++ b/src/components/common/VoiceChatModal.tsx
@@ -108,8 +108,17 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
 
         // 이벤트 리스너 등록
         Object.entries(listeners).forEach(([event, listener]) => {
-          el.addEventListener(event, listener);
-          eventListenersRef.current[participantId][event] = listener;
+          // 타입 오류 방지를 위해 listener의 시그니처를 맞춰줌
+          const wrappedListener = (e?: Event) => {
+            // error 이벤트만 이벤트 객체를 사용하고, 나머지는 무시
+            if (event === 'error') {
+              (listener as (e: Event) => void)(e as Event);
+            } else {
+              (listener as () => void)();
+            }
+          };
+          el.addEventListener(event, wrappedListener);
+          eventListenersRef.current[participantId][event] = wrappedListener;
         });
       }
     },

--- a/src/components/common/VoiceChatModal.tsx
+++ b/src/components/common/VoiceChatModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useMemo, useCallback } from 'react';
 import microphoneIcon from '../../assets/microphone.svg';
 
 interface Participant {
@@ -39,189 +39,282 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
   onParticipantVolumeChange,
   userId,
 }) => {
-  const [localVolume, setLocalVolume] = useState(volume);
-  const [previousVolume, setPreviousVolume] = useState(volume); // 이전 볼륨 저장
+  const audioRefs = useRef<{ [key: string]: HTMLAudioElement | null }>({});
+  const eventListenersRef = useRef<{ [key: string]: { [event: string]: (e?: Event) => void } }>({});
 
-  useEffect(() => {
-    setLocalVolume(volume);
-  }, [volume]);
+  // 중복 제거 및 자기 자신 제외 - useMemo로 최적화
+  const uniqueParticipants = useMemo(
+    () =>
+      participants
+        .filter((participant) => participant.id !== userId)
+        .filter(
+          (participant, index, self) => index === self.findIndex((p) => p.id === participant.id),
+        ),
+    [participants, userId],
+  );
 
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newVolume = Number(e.target.value);
-    setLocalVolume(newVolume);
-    onVolumeChange(newVolume);
-  };
+  // 오디오 엘리먼트 이벤트 리스너 정리
+  const cleanupAudioElement = useCallback((participantId: string) => {
+    const audioEl = audioRefs.current[participantId];
+    const listeners = eventListenersRef.current[participantId];
 
-  // 음소거 토글 핸들러
-  const handleMuteToggle = () => {
-    if (localVolume === 0) {
-      // 음소거 해제: 이전 볼륨으로 복원
-      const restoreVolume = previousVolume > 0 ? previousVolume : 50; // 이전 볼륨이 0이면 50으로 설정
-      setLocalVolume(restoreVolume);
-      onVolumeChange(restoreVolume);
-    } else {
-      // 음소거: 현재 볼륨을 저장하고 0으로 설정
-      setPreviousVolume(localVolume);
-      setLocalVolume(0);
-      onVolumeChange(0);
+    if (audioEl && listeners) {
+      Object.entries(listeners).forEach(([event, listener]) => {
+        audioEl.removeEventListener(event, listener);
+      });
+      delete eventListenersRef.current[participantId];
     }
-  };
+  }, []);
 
-  if (!isOpen) return null;
+  // 오디오 엘리먼트 참조 설정 시 초기화
+  const setAudioRef = useCallback(
+    (participantId: string) => (el: HTMLAudioElement | null) => {
+      // 기존 이벤트 리스너 정리
+      cleanupAudioElement(participantId);
+
+      audioRefs.current[participantId] = el;
+
+      if (el) {
+        // 이벤트 리스너 객체 초기화
+        eventListenersRef.current[participantId] = {};
+
+        // 오디오 엘리먼트 이벤트 리스너 추가
+        const listeners = {
+          loadedmetadata: () => {
+            console.log(`[VoiceChatModal] ${participantId} 오디오 메타데이터 로드됨`);
+          },
+          canplay: () => {
+            console.log(`[VoiceChatModal] ${participantId} 오디오 재생 가능`);
+          },
+          play: () => {
+            console.log(`[VoiceChatModal] ${participantId} 오디오 재생 시작`);
+          },
+          playing: () => {
+            console.log(`[VoiceChatModal] ${participantId} 오디오 재생 중`);
+          },
+          pause: () => {
+            console.log(`[VoiceChatModal] ${participantId} 오디오 일시정지`);
+          },
+          ended: () => {
+            console.log(`[VoiceChatModal] ${participantId} 오디오 종료`);
+          },
+          error: (e: Event) => {
+            console.error(`[VoiceChatModal] ${participantId} 오디오 에러:`, e);
+          },
+          stalled: () => {
+            console.warn(`[VoiceChatModal] ${participantId} 오디오 정지됨`);
+          },
+        };
+
+        // 이벤트 리스너 등록
+        Object.entries(listeners).forEach(([event, listener]) => {
+          el.addEventListener(event, listener);
+          eventListenersRef.current[participantId][event] = listener;
+        });
+      }
+    },
+    [cleanupAudioElement],
+  );
+
+  // 참여자 스트림이 변경될 때마다 오디오 엘리먼트 설정
+  useEffect(() => {
+    participants.forEach((participant) => {
+      if (participant.id !== userId && participant.stream) {
+        const audioEl = audioRefs.current[participant.id];
+        if (audioEl) {
+          // 기존 스트림과 다른 경우에만 설정
+          if (audioEl.srcObject !== participant.stream) {
+            console.log(`[VoiceChatModal] ${participant.name}의 오디오 스트림 설정`);
+            audioEl.srcObject = participant.stream;
+
+            // 스트림 설정 후 즉시 재생 시도
+            setTimeout(() => {
+              if (audioEl.srcObject) {
+                audioEl
+                  .play()
+                  .then(() => {
+                    console.log(`[VoiceChatModal] ${participant.name} 오디오 재생 성공`);
+                  })
+                  .catch((error) => {
+                    console.warn(`[VoiceChatModal] ${participant.name} 오디오 재생 실패:`, error);
+                    // 재생 실패 시 다시 시도
+                    setTimeout(() => {
+                      audioEl.play().catch((retryError) => {
+                        console.warn(
+                          `[VoiceChatModal] ${participant.name} 오디오 재생 재시도 실패:`,
+                          retryError,
+                        );
+                      });
+                    }, 500);
+                  });
+              }
+            }, 100);
+          }
+
+          // 볼륨과 음소거 상태 업데이트
+          audioEl.volume = participant.volume / 100;
+          audioEl.muted = participant.isMuted;
+        }
+      }
+    });
+  }, [participants, userId]);
+
+  // 컴포넌트 언마운트 시 모든 이벤트 리스너 정리
+  useEffect(() => {
+    return () => {
+      Object.keys(audioRefs.current).forEach((participantId) => {
+        cleanupAudioElement(participantId);
+      });
+    };
+  }, [cleanupAudioElement]);
 
   return (
-    <div className="fixed top-16 right-6 bg-slate-800 rounded-lg p-4 w-80 shadow-lg border border-slate-600 z-50">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-bold text-white">음성채팅 설정</h3>
-        <button onClick={onClose} className="text-slate-400 hover:text-white transition-colors">
-          ✕
-        </button>
-      </div>
+    <>
+      {/* 오디오 엘리먼트는 항상 렌더링 (숨김) */}
+      {uniqueParticipants.map((participant) => (
+        <audio
+          key={participant.id}
+          ref={setAudioRef(participant.id)}
+          autoPlay
+          muted={participant.isMuted}
+          hidden
+        />
+      ))}
 
-      <div className="space-y-4">
-        {/* 내 마이크 섹션 */}
-        <div className="space-y-2 p-3 bg-slate-700 rounded-lg">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <span className="text-white font-medium">내 마이크</span>
-              <button
-                onClick={onToggleEnabled}
-                className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                  isEnabled
-                    ? 'bg-red-600 hover:bg-red-700 text-white'
-                    : 'bg-green-600 hover:bg-green-700 text-white'
-                }`}
-              >
-                {isEnabled ? '퇴장' : '입장'}
-              </button>
-            </div>
-            {isEnabled && (
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={onToggleMute}
-                  className={`p-2 rounded-full transition-colors relative ${
-                    isMuted ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'
-                  }`}
-                >
-                  <img
-                    src={microphoneIcon}
-                    alt={isMuted ? '마이크 켜기' : '마이크 끄기'}
-                    className="h-4 w-4 filter invert"
+      {/* 모달은 조건부 렌더링 */}
+      {isOpen && (
+        <div className="fixed top-16 right-6 bg-slate-800 rounded-lg p-4 w-80 shadow-lg border border-slate-600 z-50">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-bold text-white">음성채팅 설정</h3>
+            <button onClick={onClose} className="text-slate-400 hover:text-white transition-colors">
+              ✕
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            {/* 내 마이크 섹션 */}
+            <div className="space-y-2 p-3 bg-slate-700 rounded-lg">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-white font-medium">내 마이크</span>
+                  <button
+                    onClick={onToggleEnabled}
+                    className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                      isEnabled
+                        ? 'bg-red-600 hover:bg-red-700 text-white'
+                        : 'bg-green-600 hover:bg-green-700 text-white'
+                    }`}
+                  >
+                    {isEnabled ? '퇴장' : '입장'}
+                  </button>
+                </div>
+                {isEnabled && (
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={onToggleMute}
+                      className={`p-2 rounded-full transition-colors relative ${
+                        isMuted ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'
+                      }`}
+                    >
+                      <img
+                        src={microphoneIcon}
+                        alt={isMuted ? '마이크 켜기' : '마이크 끄기'}
+                        className="h-4 w-4 filter invert"
+                      />
+                      {/* 마이크 끄기 시 삭선 표시 */}
+                      {isMuted && (
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <div className="w-6 h-0.5 bg-black transform -rotate-45"></div>
+                        </div>
+                      )}
+                    </button>
+                  </div>
+                )}
+              </div>
+              {isEnabled && (
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-300 text-sm">볼륨</span>
+                    <span className="text-slate-400 text-xs">{volume}%</span>
+                  </div>
+                  <input
+                    type="range"
+                    min="0"
+                    max="100"
+                    value={volume}
+                    onChange={(e) => onVolumeChange(Number(e.target.value))}
+                    className="w-full h-1 bg-slate-600 rounded-lg appearance-none cursor-pointer slider"
                   />
-                  {/* 마이크 끄기 시 삭선 표시 */}
-                  {isMuted && (
-                    <div className="absolute inset-0 flex items-center justify-center">
-                      <div className="w-6 h-0.5 bg-black transform -rotate-45"></div>
+                </div>
+              )}
+            </div>
+
+            {/* 구분선 */}
+            {isEnabled && <div className="h-px bg-slate-600"></div>}
+
+            {/* 다른 참여자들 섹션 */}
+            {isEnabled && (
+              <div className="space-y-3">
+                <h4 className="text-white font-medium text-sm">다른 참여자들</h4>
+                {uniqueParticipants.length === 0 ? (
+                  <p className="text-slate-400 text-sm text-center py-4">다른 참여자가 없습니다.</p>
+                ) : (
+                  uniqueParticipants.map((participant) => (
+                    <div key={participant.id} className="space-y-2 p-3 bg-slate-700 rounded-lg">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-white font-medium">{participant.name}</span>
+                          <span className="text-xs px-2 py-1 rounded bg-slate-600 text-slate-300">
+                            {participant.role === 'teacher' ? '선생님' : '학생'}
+                          </span>
+                        </div>
+                        <button
+                          onClick={() => onToggleParticipantMute(participant.id)}
+                          className={`p-2 rounded-full transition-colors relative ${
+                            participant.isMuted
+                              ? 'bg-red-600 hover:bg-red-700'
+                              : 'bg-green-600 hover:bg-green-700'
+                          }`}
+                        >
+                          <svg
+                            className="h-4 w-4 filter invert"
+                            fill="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+                          </svg>
+                          {participant.isMuted && (
+                            <div className="absolute inset-0 flex items-center justify-center">
+                              <div className="w-6 h-0.5 bg-black transform -rotate-45"></div>
+                            </div>
+                          )}
+                        </button>
+                      </div>
+                      <div className="space-y-1">
+                        <div className="flex items-center justify-between">
+                          <span className="text-slate-300 text-sm">볼륨</span>
+                          <span className="text-slate-400 text-xs">{participant.volume}%</span>
+                        </div>
+                        <input
+                          type="range"
+                          min="0"
+                          max="100"
+                          value={participant.volume}
+                          onChange={(e) =>
+                            onParticipantVolumeChange(participant.id, Number(e.target.value))
+                          }
+                          className="w-full h-1 bg-slate-600 rounded-lg appearance-none cursor-pointer slider"
+                        />
+                      </div>
                     </div>
-                  )}
-                </button>
+                  ))
+                )}
               </div>
             )}
           </div>
-          {isEnabled && (
-            <div className="space-y-1">
-              <div className="flex items-center justify-between">
-                <span className="text-slate-300 text-sm">볼륨</span>
-                <span className="text-slate-400 text-xs">{volume}%</span>
-              </div>
-              <input
-                type="range"
-                min="0"
-                max="100"
-                value={volume}
-                onChange={(e) => onVolumeChange(Number(e.target.value))}
-                className="w-full h-1 bg-slate-600 rounded-lg appearance-none cursor-pointer slider"
-              />
-            </div>
-          )}
         </div>
-
-        {/* 구분선 */}
-        {isEnabled && <div className="h-px bg-slate-600"></div>}
-
-        {/* 다른 참여자들 섹션 */}
-        {isEnabled && (
-          <div className="space-y-3">
-            <h4 className="text-white font-medium text-sm">다른 참여자들</h4>
-            {(() => {
-              // 중복 제거 및 자기 자신 제외: id를 기준으로 고유한 참가자만 필터링하고 자기 자신은 제외
-              const uniqueParticipants = participants.filter(
-                (participant, index, self) =>
-                  index === self.findIndex((p) => p.id === participant.id) &&
-                  participant.id !== userId, // 자기 자신 제외
-              );
-
-              return uniqueParticipants.length === 0 ? (
-                <p className="text-slate-400 text-sm text-center py-4">다른 참여자가 없습니다.</p>
-              ) : (
-                uniqueParticipants.map((participant) => (
-                  <div key={participant.id} className="space-y-2 p-3 bg-slate-700 rounded-lg">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <span className="text-white font-medium">{participant.name}</span>
-                        <span className="text-xs px-2 py-1 rounded bg-slate-600 text-slate-300">
-                          {participant.role === 'teacher' ? '선생님' : '학생'}
-                        </span>
-                      </div>
-                      <button
-                        onClick={() => onToggleParticipantMute(participant.id)}
-                        className={`p-2 rounded-full transition-colors relative ${
-                          participant.isMuted
-                            ? 'bg-red-600 hover:bg-red-700'
-                            : 'bg-green-600 hover:bg-green-700'
-                        }`}
-                      >
-                        {/* 헤드셋 아이콘 */}
-                        <svg
-                          className="h-4 w-4 filter invert"
-                          fill="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
-                        </svg>
-                        {/* 음소거 시 삭선 표시 */}
-                        {participant.isMuted && (
-                          <div className="absolute inset-0 flex items-center justify-center">
-                            <div className="w-6 h-0.5 bg-black transform -rotate-45"></div>
-                          </div>
-                        )}
-                      </button>
-                    </div>
-                    <div className="space-y-1">
-                      <div className="flex items-center justify-between">
-                        <span className="text-slate-300 text-sm">볼륨</span>
-                        <span className="text-slate-400 text-xs">{participant.volume}%</span>
-                      </div>
-                      <input
-                        type="range"
-                        min="0"
-                        max="100"
-                        value={participant.volume}
-                        onChange={(e) =>
-                          onParticipantVolumeChange(participant.id, Number(e.target.value))
-                        }
-                        className="w-full h-1 bg-slate-600 rounded-lg appearance-none cursor-pointer slider"
-                      />
-                    </div>
-                    <audio
-                      ref={(el) => {
-                        if (el && participant.stream) {
-                          el.srcObject = participant.stream;
-                          el.volume = participant.volume / 100;
-                          el.muted = participant.isMuted;
-                        }
-                      }}
-                      autoPlay
-                      hidden
-                    />
-                  </div>
-                ))
-              );
-            })()}
-          </div>
-        )}
-      </div>
-    </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/signup/SignupCard.tsx
+++ b/src/components/signup/SignupCard.tsx
@@ -88,7 +88,7 @@ const SignupCard: React.FC = () => {
               value={formData.email}
               onChange={handleInputChange}
               className="w-full h-10 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              placeholder="이메일을 입력하자"
+              placeholder="이메일을 입력하세요"
               required
             />
           </div>

--- a/src/hooks/useVoiceChat.ts
+++ b/src/hooks/useVoiceChat.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import Peer from 'simple-peer';
-import socket from '../lib/socket';
+import { OpenVidu, Session, Publisher, Subscriber } from 'openvidu-browser';
+import { createOpenViduSession, createOpenViduToken } from '../api/openviduApi';
 
 interface Participant {
   id: string;
@@ -8,122 +8,256 @@ interface Participant {
   role: 'teacher' | 'student';
   isMuted: boolean;
   volume: number;
+  stream?: MediaStream;
 }
 
 interface UseVoiceChatProps {
   roomId: string;
-  userId: string;
   userName: string;
   userRole: 'teacher' | 'student';
-  isConnected: boolean; // 연결 상태를 props로 받음
 }
 
-export const useVoiceChat = ({
-  roomId,
-  userId,
-  userName,
-  userRole,
-  isConnected,
-}: UseVoiceChatProps) => {
-  // 내 마이크 상태
-  const [isEnabled, setIsEnabled] = useState(false); // 초기값을 false로 변경
+export const useVoiceChat = ({ roomId, userName, userRole }: UseVoiceChatProps) => {
+  const [isEnabled, setIsEnabled] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
   const [volume, setVolume] = useState(100);
-
-  // 참여자 목록
   const [participants, setParticipants] = useState<Participant[]>([]);
-
-  // 참여자 스트림 목록
-  const [participantStreams, setParticipantStreams] = useState<{ [id: string]: MediaStream }>({});
-
-  // 연결 상태 - props로 받은 값 사용
   const [voiceConnected, setVoiceConnected] = useState(false);
-  const voiceConnectedRef = useRef(false);
+  const [isConnecting, setIsConnecting] = useState(false);
 
-  // Refs
-  const localStream = useRef<MediaStream | null>(null);
-  const peers = useRef<Map<string, Peer.Instance>>(new Map());
-  const audioElements = useRef<Map<string, HTMLAudioElement>>(new Map());
+  const OV = useRef<OpenVidu | null>(null);
+  const session = useRef<Session | null>(null);
+  const publisher = useRef<Publisher | null>(null);
+  const subscribers = useRef<Map<string, Subscriber>>(new Map());
+  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // 마이크 활성화/비활성화 + 음성채팅 참여 / 퇴장
-  const toggleEnabled = useCallback(async () => {
-    if (isEnabled) {
-      // 마이크 비활성화 + 음성채팅 퇴장
-      if (localStream.current) {
-        localStream.current.getTracks().forEach((track) => track.stop());
-        localStream.current = null;
-      }
-      setIsEnabled(false);
-      setIsMuted(false);
+  // 세션/토큰 발급
+  const getSessionAndToken = useCallback(async () => {
+    try {
+      const sessionRes = await createOpenViduSession(roomId);
+      const sessionId = sessionRes.data.sessionId;
+      const tokenRes = await createOpenViduToken(sessionId, 'PUBLISHER');
+      return { sessionId, token: tokenRes.data.token };
+    } catch (error) {
+      console.error('[useVoiceChat] 세션/토큰 발급 실패:', error);
+      throw new Error('세션 생성에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+  }, [roomId]);
 
-      // 음성채팅 퇴장 - 모든 피어 연결 정리
-      peers.current.forEach((peer) => peer.destroy());
-      peers.current.clear();
-      audioElements.current.forEach((audio) => audio.remove());
-      audioElements.current.clear();
-      setParticipantStreams({}); // 참여자 스트림 목록 초기화
+  // 정리 함수
+  const cleanup = useCallback(() => {
+    console.log('[useVoiceChat] 정리 시작');
 
-      // 참여자 목록 초기화
-      setParticipants([]);
+    // 재시도 타이머 정리
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
 
-      // 서버에 음성채팅 퇴장 알림 전송
-      socket.emit('voice:leave', { roomId, userId });
-
-      // 음성채팅 연결 상태 리셋
-      setVoiceConnected(false);
-      voiceConnectedRef.current = false;
-
-      console.log('음성채팅 퇴장 완료');
-    } else {
-      // 마이크 활성화 + 음성채팅 참가
+    // 세션 정리
+    if (session.current) {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          audio: {
-            echoCancellation: true, // 에코(울림) 제거
-            noiseSuppression: true, // 배경 잡음 제거
-            autoGainControl: true, // 자동 볼륨 조절
-            channelCount: 2, // 2: 스테레오, 1: 모노
-            sampleRate: 48000, // 샘플레이트(Hz), 48000이 고음질 표준
-            sampleSize: 16, // 샘플 비트수(16비트가 일반적)
-          },
-        });
-        localStream.current = stream;
-        setIsEnabled(true);
-
-        // 음성채팅 참가
-        if (isConnected && !voiceConnectedRef.current) {
-          setVoiceConnected(true);
-          voiceConnectedRef.current = true;
-
-          socket.emit('voice:join', { roomId, userId, userName, userRole });
-          console.log('음성채팅 참가 완료');
-        }
-
-        // 기존 피어들에게 새로운 스트림 전송
-        peers.current.forEach((peer, peerId) => {
-          if (peer.streams && peer.streams[0]) {
-            peer.replaceTrack(
-              peer.streams[0].getAudioTracks()[0],
-              stream.getAudioTracks()[0],
-              peer.streams[0],
-            );
-          }
-        });
+        session.current.disconnect();
       } catch (error) {
-        console.error('마이크 접근 실패:', error);
-        alert('마이크 접근 권한이 필요합니다.');
+        console.warn('[useVoiceChat] 세션 정리 중 에러:', error);
       }
     }
-  }, [isEnabled, isConnected, roomId, userId, userName, userRole]);
+
+    // 참조 정리
+    OV.current = null;
+    session.current = null;
+    publisher.current = null;
+    subscribers.current.clear();
+
+    // 상태 초기화
+    setParticipants([]);
+    setIsEnabled(false);
+    setIsMuted(false);
+    setVoiceConnected(false);
+    setIsConnecting(false);
+
+    console.log('[useVoiceChat] 정리 완료');
+  }, []);
+
+  // 음성채팅 입장/퇴장
+  const toggleEnabled = useCallback(async () => {
+    if (isEnabled) {
+      cleanup();
+      return;
+    }
+
+    if (isConnecting) {
+      console.log('[useVoiceChat] 이미 연결 중입니다.');
+      return;
+    }
+
+    setIsConnecting(true);
+
+    try {
+      const { sessionId, token } = await getSessionAndToken();
+      console.log(`[useVoiceChat] 세션/토큰 발급 완료: ${sessionId}`);
+
+      OV.current = new OpenVidu();
+      session.current = OV.current.initSession();
+      console.log(`[useVoiceChat] OpenVidu 세션 초기화 완료`);
+
+      // 스트림 생성 이벤트
+      session.current.on('streamCreated', (event: any) => {
+        console.log(
+          `[useVoiceChat] streamCreated 이벤트 발생:`,
+          event.stream.connection.connectionId,
+        );
+        const connectionId = event.stream.connection.connectionId;
+
+        // 자기 자신은 제외
+        if (connectionId === session.current!.connection.connectionId) {
+          console.log(`[useVoiceChat] 자기 자신의 스트림이므로 제외: ${connectionId}`);
+          return;
+        }
+
+        console.log(`[useVoiceChat] 스트림 생성됨: ${connectionId}`);
+
+        // 스트림 구독
+        const subscriber = session.current!.subscribe(event.stream, undefined);
+        subscribers.current.set(connectionId, subscriber);
+        console.log(`[useVoiceChat] 스트림 구독 완료: ${connectionId}`);
+
+        // 참여자 정보 파싱
+        let participantName = '참여자';
+        let participantRole: 'teacher' | 'student' = 'student';
+
+        if (event.stream.connection.data) {
+          try {
+            const outerData = JSON.parse(event.stream.connection.data);
+            const clientData = JSON.parse(outerData.clientData);
+            participantName = clientData.name || '참여자';
+            participantRole = clientData.role === 'teacher' ? 'teacher' : 'student';
+            console.log(`[useVoiceChat] 참여자 정보 파싱: ${participantName} (${participantRole})`);
+          } catch (error) {
+            console.warn('clientData 파싱 실패:', error);
+          }
+        }
+
+        // 참여자 추가
+        setParticipants((prev) => {
+          if (prev.find((p) => p.id === connectionId)) {
+            console.log(`[useVoiceChat] 이미 존재하는 참여자: ${connectionId}`);
+            return prev;
+          }
+          console.log(`[useVoiceChat] 새 참여자 추가: ${participantName}`);
+          return [
+            ...prev,
+            {
+              id: connectionId,
+              name: participantName,
+              role: participantRole,
+              isMuted: false,
+              volume: 100,
+              stream: undefined,
+            },
+          ];
+        });
+
+        // 스트림 재생 시 참여자 스트림 설정
+        subscriber.on('streamPlaying', () => {
+          console.log(`[useVoiceChat] ${participantName} 스트림 재생 시작`);
+          try {
+            const mediaStream = subscriber.stream.getMediaStream();
+            console.log(
+              `[useVoiceChat] ${participantName} streamPlaying에서 미디어 스트림:`,
+              !!mediaStream,
+            );
+            if (mediaStream) {
+              setParticipants((prev) =>
+                prev.map((p) => (p.id === connectionId ? { ...p, stream: mediaStream } : p)),
+              );
+            } else {
+              console.warn(
+                `[useVoiceChat] ${participantName} streamPlaying에서 미디어 스트림이 null입니다`,
+              );
+            }
+          } catch (error) {
+            console.error(`[useVoiceChat] ${participantName} streamPlaying 에러:`, error);
+          }
+        });
+
+        // ICE 연결 완료 후 스트림 설정 (streamPlaying 이벤트가 발생하지 않는 경우 대비)
+        const checkAndSetStream = () => {
+          try {
+            const mediaStream = subscriber.stream.getMediaStream();
+            if (mediaStream) {
+              console.log(`[useVoiceChat] ${participantName} ICE 연결 후 스트림 설정`);
+              setParticipants((prev) =>
+                prev.map((p) => (p.id === connectionId ? { ...p, stream: mediaStream } : p)),
+              );
+            }
+          } catch (error) {
+            console.warn(`[useVoiceChat] ${participantName} ICE 연결 후 스트림 설정 실패:`, error);
+          }
+        };
+
+        // ICE 연결 완료 후 1초, 3초, 5초에 스트림 설정 시도
+        setTimeout(checkAndSetStream, 1000);
+        setTimeout(checkAndSetStream, 3000);
+        setTimeout(checkAndSetStream, 5000);
+      });
+
+      // 스트림 제거 이벤트
+      session.current.on('streamDestroyed', (event: any) => {
+        const connectionId = event.stream.connection.connectionId;
+        console.log(`[useVoiceChat] 스트림 제거: ${connectionId}`);
+        subscribers.current.delete(connectionId);
+        setParticipants((prev) => prev.filter((p) => p.id !== connectionId));
+      });
+
+      // 세션 연결
+      const clientDataString = JSON.stringify({
+        name: userName,
+        role: userRole,
+      });
+
+      console.log(`[useVoiceChat] 세션 연결 시작: ${userName} (${userRole})`);
+      await session.current.connect(token, {
+        clientData: clientDataString,
+      });
+      console.log(`[useVoiceChat] 세션 연결 완료`);
+
+      // Publisher 생성
+      publisher.current = OV.current.initPublisher(undefined, {
+        audioSource: undefined,
+        videoSource: false,
+        publishAudio: true,
+        publishVideo: false,
+      });
+      console.log(`[useVoiceChat] Publisher 생성 완료`);
+
+      await session.current.publish(publisher.current);
+      console.log(`[useVoiceChat] Publisher 발행 완료`);
+
+      setIsEnabled(true);
+      setVoiceConnected(true);
+      setIsConnecting(false);
+      console.log(`[useVoiceChat] 음성채팅 입장 완료`);
+    } catch (error) {
+      console.error('OpenVidu 입장 실패:', error);
+      setIsConnecting(false);
+
+      // 에러 메시지 표시
+      const errorMessage = error instanceof Error ? error.message : '음성채팅 입장에 실패했습니다.';
+      alert(errorMessage);
+
+      // 정리
+      cleanup();
+    }
+  }, [isEnabled, isConnecting, getSessionAndToken, userName, userRole, cleanup]);
 
   // 음소거 토글
   const toggleMute = useCallback(() => {
-    if (localStream.current) {
-      localStream.current.getAudioTracks().forEach((track) => {
-        track.enabled = !track.enabled;
-      });
-    }
-    setIsMuted(!isMuted);
+    const pub = publisher.current;
+    if (!pub) return;
+    const newMuted = !isMuted;
+    pub.publishAudio(!newMuted);
+    setIsMuted(newMuted);
   }, [isMuted]);
 
   // 볼륨 변경
@@ -134,18 +268,7 @@ export const useVoiceChat = ({
   // 참여자 음소거 토글
   const toggleParticipantMute = useCallback((participantId: string) => {
     setParticipants((prev) =>
-      prev.map((p) => {
-        if (p.id === participantId) {
-          const newMuted = !p.isMuted;
-          // 실제 오디오 음소거 처리
-          const audioElement = audioElements.current.get(participantId);
-          if (audioElement) {
-            audioElement.muted = newMuted;
-          }
-          return { ...p, isMuted: newMuted };
-        }
-        return p;
-      }),
+      prev.map((p) => (p.id === participantId ? { ...p, isMuted: !p.isMuted } : p)),
     );
   }, []);
 
@@ -154,349 +277,26 @@ export const useVoiceChat = ({
     setParticipants((prev) =>
       prev.map((p) => (p.id === participantId ? { ...p, volume: newVolume } : p)),
     );
-
-    // 실제 오디오 볼륨 변경
-    const audioElement = audioElements.current.get(participantId);
-    if (audioElement) {
-      audioElement.volume = newVolume / 100;
-    }
   }, []);
 
-  // 참여자 추가
-  const addParticipant = useCallback((participant: Participant) => {
-    if (!participant.id || participant.id === 'undefined') {
-      console.warn('잘못된 participantId로 참가자 추가 시도, 스킵:', participant.id);
-      return (prev: any[]) => prev;
-    }
-    setParticipants((prev) => {
-      // 중복 체크
-      const existing = prev.find((p) => p.id === participant.id);
-      if (existing) {
-        console.log('이미 존재하는 참가자 (스킵):', participant.id, participant.name);
-        return prev;
-      }
-
-      console.log('새 참가자 추가:', participant.id, participant.name);
-      console.log(
-        '현재 참여자 목록:',
-        prev.map((p) => `${p.id}:${p.name}`),
-      );
-      const newList = [...prev, participant];
-      console.log(
-        '추가 후 참여자 목록:',
-        newList.map((p) => `${p.id}:${p.name}`),
-      );
-      return newList;
-    });
-  }, []);
-
-  // 참여자 제거
-  const removeParticipant = useCallback((participantId: string) => {
-    console.log('참여자 제거 시도:', participantId);
-
-    setParticipants((prev) => {
-      console.log(
-        '제거 전 참여자 목록:',
-        prev.map((p) => `${p.id}:${p.name}`),
-      );
-      const filtered = prev.filter((p) => p.id !== participantId);
-      console.log(
-        '제거 후 참여자 목록:',
-        filtered.map((p) => `${p.id}:${p.name}`),
-      );
-      console.log('제거 전 참여자 수:', prev.length, '제거 후 참여자 수:', filtered.length);
-      return filtered;
-    });
-
-    setParticipantStreams((prev) => {
-      const newObj = { ...prev };
-      delete newObj[participantId];
-      return newObj;
-    });
-
-    // 피어 연결 정리
-    const peer = peers.current.get(participantId);
-    if (peer) {
-      peer.destroy();
-      peers.current.delete(participantId);
-      console.log('피어 연결 정리 완료:', participantId);
-    }
-
-    // 오디오 요소 정리
-    const audioElement = audioElements.current.get(participantId);
-    if (audioElement) {
-      audioElement.remove();
-      audioElements.current.delete(participantId);
-      console.log('오디오 요소 정리 완료:', participantId);
-    }
-  }, []);
-
-  // 새로운 피어 연결 생성
-  const createPeer = useCallback(
-    (participantId: string) => {
-      if (!participantId || participantId === 'undefined') {
-        console.warn('잘못된 participantId로 피어 생성 시도, 스킵:', participantId);
-        return;
-      }
-      // 이미 피어가 있으면 생성하지 않음
-      if (peers.current.has(participantId)) {
-        console.log('이미 피어가 존재 (생성 스킵):', participantId);
-        return peers.current.get(participantId)!;
-      }
-      // initiator 분기: 내 userId가 더 작으면 initiator, 아니면 responder
-      const initiator = Number(userId) < Number(participantId);
-      console.log('새 피어 생성:', participantId, 'initiator:', initiator);
-      const peer = new Peer({
-        initiator,
-        trickle: true, // ICE 후보를 개별적으로 교환
-        stream: localStream.current || undefined,
-        config: {
-          iceServers: [
-            { urls: 'stun:stun.l.google.com:19302' },
-            { urls: 'stun:stun1.l.google.com:19302' },
-            { urls: 'stun:stun2.l.google.com:19302' },
-            { urls: 'stun:stun3.l.google.com:19302' },
-            { urls: 'stun:stun4.l.google.com:19302' },
-          ],
-        },
-      });
-
-      peer.on('signal', (data: any) => {
-        socket.emit('voice:signal', {
-          roomId,
-          to: Number(participantId), // string → number 변환
-          signal: data,
-        });
-      });
-
-      peer.on('stream', (stream: MediaStream) => {
-        setParticipantStreams((prev) => ({ ...prev, [participantId]: stream }));
-        // 기존 audioElements 관련 코드는 유지(볼륨 동기화용)
-        const audio = new Audio();
-        audio.srcObject = stream;
-        audio.volume = volume / 100;
-        audio.play().catch(console.error);
-        audioElements.current.set(participantId, audio);
-      });
-
-      peer.on('close', () => {
-        console.log('피어 연결 종료:', participantId);
-        // 피어 연결 정리
-        peers.current.delete(participantId);
-        // 오디오 요소 정리
-        const audioElement = audioElements.current.get(participantId);
-        if (audioElement) {
-          audioElement.remove();
-          audioElements.current.delete(participantId);
-        }
-      });
-
-      peer.on('error', (err) => {
-        console.error('피어 연결 에러:', participantId, err);
-      });
-
-      peer.on('connect', () => {
-        console.log('피어 연결 성공:', participantId);
-        // 데이터 채널 닫기
-        // if ((peer as any)._channel) {
-        //   try {
-        //     (peer as any)._channel.close();
-        //     console.log('데이터 채널 닫음:', participantId);
-        //   } catch (e) {
-        //     console.warn('데이터 채널 닫기 실패:', participantId, e);
-        //   }
-        // }
-        // ICE 상태 이벤트 바인딩
-        const pc = (peer as any)._pc as RTCPeerConnection;
-        if (pc) {
-          pc.oniceconnectionstatechange = () => {
-            console.log('ICE 상태:', pc.iceConnectionState, participantId);
-          };
-        }
-      });
-
-      peers.current.set(participantId, peer);
-      return peer;
-    },
-    [roomId, volume, userId],
-  );
-
-  // 음성채팅 이벤트 리스너 설정
-  const setupVoiceChatListeners = useCallback(() => {
-    // 이미 등록된 리스너가 있으면 제거
-    socket.off('voice:user-joined');
-    socket.off('voice:signal');
-    socket.off('voice:leave');
-    socket.off('voice:existing-participants');
-
-    // 새로운 참가자 입장
-    const handleVoiceUserJoined = ({
-      userId: newUserId,
-      userName: newUserName,
-      userRole: newUserRole,
-    }: {
-      userId: number;
-      userName: string;
-      userRole: 'teacher' | 'student';
-    }) => {
-      // 내 정보는 제외
-      if (String(newUserId) !== userId) {
-        const participantId = String(newUserId);
-        if (!participantId || participantId === 'undefined') {
-          console.warn('잘못된 participantId로 handleVoiceUserJoined, 스킵:', participantId);
-          return;
-        }
-        const peer = peers.current.get(participantId);
-        // 중복 체크 강화: 피어가 있거나, 스트림이 있거나, 피어가 연결된 상태면 스킵
-        if (
-          peer ||
-          participantStreams[participantId] ||
-          (peer ? (peer as any).connected || (peer as any)._connected : false)
-        ) {
-          console.log('이미 피어/스트림/연결된 참가자 (스킵):', participantId);
-          return;
-        }
-        const newParticipant: Participant = {
-          id: participantId,
-          name: newUserName,
-          role: newUserRole,
-          isMuted: false,
-          volume: 100,
-        };
-        addParticipant(newParticipant);
-        createPeer(participantId);
-      }
-    };
-
-    // 시그널링 데이터 수신
-    const handleVoiceSignal = ({ from, signal }: { from: number; signal: any }) => {
-      const fromId = String(from);
-      let peer = peers.current.get(fromId);
-      if (!peer) {
-        peer = createPeer(fromId);
-      }
-      // 이미 연결된 피어면 signal 처리하지 않음
-      if (peer && (peer.destroyed || peer.connected)) {
-        console.log('이미 연결된 피어 signal 무시:', fromId);
-        return;
-      }
-      if (peer) {
-        peer.signal(signal);
-      }
-    };
-
-    // 참가자 퇴장
-    const handleVoiceLeave = ({ userId: leftUserId }: { userId: number }) => {
-      console.log('참가자 퇴장 이벤트 수신:', leftUserId, '타입:', typeof leftUserId);
-      const participantId = String(leftUserId);
-      console.log('변환된 participantId:', participantId);
-      removeParticipant(participantId);
-    };
-
-    // 기존 참가자 목록 수신
-    const handleVoiceExistingParticipants = (
-      participants: Array<{
-        userId: number;
-        userName: string;
-        userRole: 'teacher' | 'student';
-      }>,
-    ) => {
-      participants.forEach((participant) => {
-        // 내 정보는 제외
-        if (String(participant.userId) !== userId) {
-          const participantId = String(participant.userId);
-          if (!participantId || participantId === 'undefined') {
-            console.warn(
-              '잘못된 participantId로 handleVoiceExistingParticipants, 스킵:',
-              participantId,
-            );
-            return;
-          }
-          const peer = peers.current.get(participantId);
-          // 중복 체크 강화: 피어가 있거나, 스트림이 있거나, 피어가 연결된 상태면 스킵
-          if (
-            peer ||
-            participantStreams[participantId] ||
-            (peer && ((peer as any).connected || (peer as any)._connected))
-          ) {
-            console.log('기존 참가자 피어/스트림/연결된 참가자 (스킵):', participantId);
-            return;
-          }
-          const newParticipant: Participant = {
-            id: participantId,
-            name: participant.userName,
-            role: participant.userRole,
-            isMuted: false,
-            volume: 100,
-          };
-          addParticipant(newParticipant);
-          createPeer(participantId);
-        }
-      });
-    };
-
-    // 이벤트 리스너 등록
-    socket.on('voice:user-joined', handleVoiceUserJoined);
-    socket.on('voice:signal', handleVoiceSignal);
-    socket.on('voice:leave', handleVoiceLeave);
-    socket.on('voice:existing-participants', handleVoiceExistingParticipants);
-
-    // 클린업 함수 반환
-    return () => {
-      socket.off('voice:user-joined', handleVoiceUserJoined);
-      socket.off('voice:signal', handleVoiceSignal);
-      socket.off('voice:leave', handleVoiceLeave);
-      socket.off('voice:existing-participants', handleVoiceExistingParticipants);
-    };
-  }, [roomId, userId, userName, userRole, addParticipant, removeParticipant, createPeer]);
-
-  // 컴포넌트 마운트 시 이벤트 리스너 등록 및 언마운트 시 정리
+  // 컴포넌트 언마운트 시 정리
   useEffect(() => {
-    // 이벤트 리스너 등록
-    const cleanup = setupVoiceChatListeners();
-
     return () => {
       cleanup();
-      // 연결 정리
-      if (localStream.current) {
-        localStream.current.getTracks().forEach((track) => track.stop());
-      }
-      peers.current.forEach((peer) => peer.destroy());
-      peers.current.clear();
-      audioElements.current.forEach((audio) => audio.remove());
-      audioElements.current.clear();
-      setParticipantStreams({}); // 참여자 스트림 목록 초기화
     };
-  }, [setupVoiceChatListeners]);
-
-  // 볼륨 동기화용 useEffect
-  useEffect(() => {
-    audioElements.current.forEach((audio) => {
-      audio.volume = volume / 100;
-    });
-  }, [volume]);
-
-  // participants에 stream을 붙여서 반환
-  const participantsWithStream = participants.map((p) => ({
-    ...p,
-    stream: participantStreams[p.id],
-  }));
+  }, [cleanup]);
 
   return {
-    // 내 상태
     isEnabled,
     isMuted,
     volume,
+    isConnecting,
     toggleEnabled,
     toggleMute,
     handleVolumeChange,
-
-    // 참여자 관리
-    participants: participantsWithStream,
+    participants,
     toggleParticipantMute,
     handleParticipantVolumeChange,
-
-    // 연결 상태
     isConnected: voiceConnected,
   };
 };

--- a/src/pages/StudentClassPage.tsx
+++ b/src/pages/StudentClassPage.tsx
@@ -114,10 +114,8 @@ const StudentClassPage: React.FC = () => {
   // 음성채팅 훅 사용
   const voiceChat = useVoiceChat({
     roomId: roomId!,
-    userId: user?.id?.toString() || '',
     userName: user?.name || '',
     userRole: 'student',
-    isConnected: isRoomJoined, // 방 입장 완료 후에만 true
   });
 
   useEffect(() => {

--- a/src/pages/TeacherClassPage.tsx
+++ b/src/pages/TeacherClassPage.tsx
@@ -50,7 +50,6 @@ const TeacherClassPage: React.FC = () => {
   const [isVoiceChatOpen, setIsVoiceChatOpen] = useState(false);
   const [isRoomJoined, setIsRoomJoined] = useState(false);
   const [infoMessage, setInfoMessage] = useState<string | null>(null);
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const {
     currentRoom,
@@ -85,10 +84,8 @@ const TeacherClassPage: React.FC = () => {
   // 음성채팅 훅 사용
   const voiceChat = useVoiceChat({
     roomId: roomId!,
-    userId: user?.id?.toString() || '',
     userName: user?.name || '',
     userRole: 'teacher',
-    isConnected: isRoomJoined, // 방 입장 완료 후에만 true
   });
 
   // 즉시 반영되는 수업 상태 (UI용)
@@ -344,7 +341,7 @@ const TeacherClassPage: React.FC = () => {
     };
   }, [selectedStudentId]);
 
-  console.log('현재 스토어의 currentRoom 상태:', currentRoom);
+  //console.log('현재 스토어의 currentRoom 상태:', currentRoom);
 
   const handleToggleClass = async (currentTimer?: string) => {
     setLocalClassStarted((prev) => !prev);
@@ -437,8 +434,8 @@ const TeacherClassPage: React.FC = () => {
     currentRoom?.participants?.filter((p: any) => p.userType !== 'teacher') || [];
 
   // 디버깅용 로그
-  console.log('currentRoom.participants:', currentRoom?.participants);
-  console.log('studentsWithoutTeacher:', studentsWithoutTeacher);
+  //console.log('currentRoom.participants:', currentRoom?.participants);
+  //console.log('studentsWithoutTeacher:', studentsWithoutTeacher);
 
   // 헬퍼 함수: collaborationId에서 studentId 추출하여 코드 업데이트
   const updateStudentCodeFromCollaborationId = (

--- a/src/pages/TeacherClassPage.tsx
+++ b/src/pages/TeacherClassPage.tsx
@@ -107,7 +107,6 @@ const TeacherClassPage: React.FC = () => {
     socket.on('room:joined', (data) => {
       console.log('[Teacher] room:joined', data);
       setIsRoomJoined(true); // 방 입장 완료 시 상태 업데이트
-      setIsVoiceChatOpen(true); // 방 입장 완료 시 음성채팅 팝업 열기
     });
     socket.on('room:full', () => console.log('[Teacher] room:full'));
     socket.on('room:notfound', () => console.log('[Teacher] room:notfound'));


### PR DESCRIPTION
closes #132 

**주요 변경사항**

**P2P → SFU 전환으로 개선된 점**

- **네트워크 안정성**: P2P는 NAT/방화벽 문제로 연결 실패가 많았으나, SFU는 중앙 서버를 통해 안정적 연결
- **확장성**: P2P는 참여자 수 증가 시 연결 복잡도가 기하급수적으로 증가, SFU는 선형적 증가
- **품질 일관성**: P2P는 참여자 간 직접 연결로 품질 편차가 컸으나, SFU는 서버를 통한 일관된 품질 제공
- **장애 대응**: P2P는 한 참여자 연결 끊어지면 전체 영향, SFU는 개별 참여자만 영향

**프론트엔드 주요 변경점**

- **참여자 식별 방식**: 기존 userId → OpenVidu connectionId 사용
- **스트림 관리**: 직접 P2P 연결 → OpenVidu 세션을 통한 중앙 관리
- **상태 관리**: 로컬 상태 → OpenVidu 이벤트 기반 상태 동기화
- **에러 처리**: 단순 연결 실패 → OpenVidu 세션 레벨 에러 처리

**OpenVidu의 핵심 개념**

- **Session**: 음성채팅 방을 의미하는 논리적 단위
- **Publisher**: 자신의 음성/영상을 서버로 전송하는 역할
- **Subscriber**: 다른 참여자의 음성/영상을 서버로부터 수신하는 역할
- **Token**: 세션에 참여하기 위한 인증 키
- **Connection**: 세션 내 개별 참여자의 연결 정보

**연동 흐름**

1.  **세션 생성**: 백엔드에서 OpenVidu 서버에 세션 생성 요청
2.  **토큰 발급**: 백엔드에서 해당 세션의 참여 토큰 발급
3.  **세션 연결**: 프론트엔드에서 토큰으로 OpenVidu 세션 연결
4.  **Publisher 생성**: 자신의 음성 스트림을 서버로 전송 시작
5.  **스트림 구독**: 다른 참여자의 스트림을 서버로부터 수신 시작
6.  **실시간 통신**: Publisher/Subscriber를 통한 양방향 음성 통신

**이벤트 기반 상태 관리**

- **streamCreated**: 새로운 참여자가 음성 스트림을 시작할 때
- **streamDestroyed**: 참여자가 음성 스트림을 종료할 때
- **streamPlaying**: 다른 참여자의 음성이 재생 시작될 때
- **connectionCreated**: 새로운 참여자가 세션에 입장할 때
- **connectionDestroyed**: 참여자가 세션에서 퇴장할 때

**테스트 및 검증**

**SFU 연결 테스트**

- OpenVidu SFU 서버와 안정적 연결 확인
- 다중 참여자 동시 입장 시 스트림 중계 검증
- NAT/방화벽 환경에서도 정상 연결 확인

**참여자 관리 검증**

- connectionId 기반 참여자 식별 정상 작동
- 이중 JSON 구조의 clientData 파싱 정확성 확인
- 참여자 입장/퇴장 시 목록 동기화 검증

**메모리 관리 검증**

- 세션 연결 해제 시 모든 리소스 정리 확인
- 이벤트 리스너 메모리 누수 방지 검증
- 장시간 사용 시 안정성 확인

** 요약**

기존 P2P 방식의 네트워크 불안정성과 확장성 문제를 해결하기 위해 OpenVidu SFU 방식으로 전환했습니다. Publisher/Subscriber 패턴을 통해 중앙 서버를 통한 스트림 중계로 안정적이고 확장 가능한 음성채팅을 구현했으며, 이벤트 기반 상태 관리로 실시간 참여자 동기화를 제공합니다. connectionId 기반 참여자 관리로 더욱 정확한 사용자 경험을 제공합니다.

---

** fix: 선생 입장 시 모달 안뜨게(), voicemodal lint - 빨간줄 해결 까지 했습니다.