### PR TITLE
fix(#158): 마이페이지 리포트 변경, 프로필 삭제 (UI만 변경)

### DIFF
--- a/src/components/mypage/AccountManagementView.tsx
+++ b/src/components/mypage/AccountManagementView.tsx
@@ -23,27 +23,11 @@ const MyAccountManagementView: React.FC<MyAccountComponentProps> = ({
       </div>
       {/* Container with responsive layout */}
       <div className="relative w-full">
-        {/* Profile Avatar */}
-        <div className="flex justify-center mb-16">
-          <div className="w-32 h-32 sm:w-40 sm:h-40 lg:w-64 lg:h-64 rounded-full bg-gray-300 flex-shrink-0">
-            <svg
-              width="100%"
-              height="100%"
-              viewBox="0 0 257 257"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              className="rounded-full"
-            >
-              <circle cx="128.5" cy="128.5" r="128.5" fill="#D9D9D9" />
-            </svg>
-          </div>
-        </div>
-
         {/* User Information Section */}
-        <div className="grid grid-cols-2 gap-8 mb-20">
+        <div className="grid grid-cols-2 gap-8 mb-20 mt-10">
           {/* Name Field */}
           <div className="w-full">
-            <label className="block text-gray-700 font-bold text-xl leading-6 mb-2">이름</label>
+            <label className="text-gray-700 font-bold text-xl leading-6 mb-2">이름</label>
             <div className="w-full h-14 rounded-lg border border-gray-200 bg-gray-50 flex items-center px-4">
               <span className="text-black font-normal text-base leading-6">{userName}</span>
             </div>
@@ -51,7 +35,7 @@ const MyAccountManagementView: React.FC<MyAccountComponentProps> = ({
 
           {/* Email Field */}
           <div className="w-full">
-            <label className="block text-gray-700 font-bold text-xl leading-6 mb-2">이메일</label>
+            <label className="text-gray-700 font-bold text-xl leading-6 mb-2">이메일</label>
             <div className="w-full h-14 rounded-lg border border-gray-200 bg-gray-50 flex items-center px-4">
               <span className="text-black font-normal text-base leading-6">{userEmail}</span>
             </div>

--- a/src/components/mypage/ClassSummaryCard.tsx
+++ b/src/components/mypage/ClassSummaryCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Calendar, Users, Clock, ChevronRight } from 'lucide-react';
+
+interface ClassSummaryCardProps {
+  title: string;
+  date: string;
+  participantCount: number;
+  successRate: number;
+  categories: string[];
+  onClick?: () => void;
+}
+
+const ClassSummaryCard: React.FC<ClassSummaryCardProps> = ({
+  title,
+  date,
+  participantCount,
+  successRate,
+  categories,
+  onClick,
+}) => {
+  return (
+    <div
+      onClick={onClick}
+      className="w-full bg-white rounded-xl border border-gray-200 shadow-sm p-4 hover:shadow-md transition-shadow cursor-pointer"
+    >
+      <div className="flex justify-between items-center h-full">
+        {/* 왼쪽 정보 영역 */}
+        <div className="flex flex-col justify-between h-full">
+          <div>
+            <h3 className="text-lg font-bold text-gray-800 mb-2">{title}</h3>
+            <div className="flex items-center space-x-4 text-sm text-gray-500">
+              <div className="flex items-center gap-1">
+                <Calendar className="w-4 h-4" />
+                <span>{date}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Users className="w-4 h-4" />
+                <span>{participantCount}명</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Clock className="w-4 h-4" />
+                <span>정답률 {successRate}%</span>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {categories.slice(0, 2).map((category, index) => (
+              <span
+                key={index}
+                className="px-3 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800"
+              >
+                {category}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* 오른쪽 화살표 아이콘 */}
+        <div className="flex items-center">
+          <ChevronRight className="w-6 h-6 text-gray-400" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ClassSummaryCard;

--- a/src/components/mypage/CreatedClassesView.tsx
+++ b/src/components/mypage/CreatedClassesView.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ClassSummaryCard from './ClassSummaryCard';
+
+// 이 컴포넌트가 받을 데이터의 타입
+interface ClassData {
+  title: string;
+  date: string;
+  participantCount: number;
+  successRate: number;
+  categories: string[];
+}
+
+interface CreatedClassesViewProps {
+  classes: ClassData[];
+}
+
+const CreatedClassesView: React.FC<CreatedClassesViewProps> = ({ classes }) => {
+  return (
+    <div className="space-y-4">
+      {classes.map((classInfo, index) => (
+        <ClassSummaryCard key={index} {...classInfo} />
+      ))}
+    </div>
+  );
+};
+export default CreatedClassesView;

--- a/src/components/mypage/JoinedClassesView.tsx
+++ b/src/components/mypage/JoinedClassesView.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ClassSummaryCard from './ClassSummaryCard';
+
+// 이 컴포넌트가 받을 데이터의 타입
+interface ClassData {
+  title: string;
+  date: string;
+  participantCount: number;
+  successRate: number;
+  categories: string[];
+}
+
+interface JoinedClassesViewProps {
+  classes: ClassData[];
+}
+
+const JoinedClassesView: React.FC<JoinedClassesViewProps> = ({ classes }) => {
+  return (
+    <div className="space-y-4">
+      {classes.map((classInfo, index) => (
+        <ClassSummaryCard key={index} {...classInfo} />
+      ))}
+    </div>
+  );
+};
+export default JoinedClassesView;

--- a/src/components/mypage/MyPageLeftSide.tsx
+++ b/src/components/mypage/MyPageLeftSide.tsx
@@ -12,9 +12,9 @@ interface MyPageLeftSideProps {
 
 const MyPageLeftSide: React.FC<MyPageLeftSideProps> = ({ onItemClick, activeItem }) => {
   const navItems: NavItem[] = [
+    { label: '계정 관리', key: 'account-management' },
     { label: '리포트', key: 'report' },
     { label: '문제 관리', key: 'problem-management' },
-    { label: '계정 관리', key: 'account-management' },
   ];
 
   const handleItemClick = (key: string) => {

--- a/src/components/mypage/MyPageReportBox.tsx
+++ b/src/components/mypage/MyPageReportBox.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import CreatedClassesView from './CreatedClassesView'; // 👈 뷰 import
+import JoinedClassesView from './JoinedClassesView'; // 👈 뷰 import
+
+const mockCreatedClasses = [
+  {
+    title: '자료구조 스터디',
+    date: '2025-07-15',
+    participantCount: 12,
+    successRate: 45,
+    categories: ['그리디', 'BF'],
+  },
+];
+const mockJoinedClasses = [
+  {
+    title: '알고리즘 특강',
+    date: '2025-07-12',
+    participantCount: 8,
+    successRate: 68,
+    categories: ['DP', '백트래킹'],
+  },
+];
+
+interface MyPageReportBoxProps {
+  className?: string;
+  onTabChange?: (tab: 'create' | 'join') => void;
+  onSortChange?: (sort: string) => void;
+}
+
+const MyPageReportBox: React.FC<MyPageReportBoxProps> = ({
+  className = '',
+  onTabChange,
+  onSortChange,
+}) => {
+  const [activeTab, setActiveTab] = useState<'create' | 'join'>('create');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [selectedSort, setSelectedSort] = useState('최신순');
+
+  const handleTabClick = (tab: 'create' | 'join') => {
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
+
+  const handleSortSelect = (sort: string) => {
+    setSelectedSort(sort);
+    setIsDropdownOpen(false);
+    onSortChange?.(sort);
+  };
+
+  return (
+    <div className={`w-full h-full flex flex-col ${className}`}>
+      {/* 제목 */}
+      <div className="flex-shrink-0">
+        <h1 className="text-black font-bold text-[32px] leading-[48px] mb-1">리포트</h1>
+        <span className="text-gray-500">내 리포트를 볼 수 있습니다.</span>
+      </div>
+
+      {/* 탭과 정렬 드롭다운을 묶는 컨트롤 바 */}
+      <div className="flex justify-between items-center my-6 flex-shrink-0">
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleTabClick('create')}
+            className={`px-4 py-2 rounded-lg text-sm transition-colors ${
+              activeTab === 'create'
+                ? 'bg-indigo-600 text-white'
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+            }`}
+          >
+            수업 생성
+          </button>
+          <button
+            onClick={() => handleTabClick('join')}
+            className={`px-4 py-2 rounded-lg text-sm transition-colors ${
+              activeTab === 'join'
+                ? 'bg-indigo-600 text-white'
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+            }`}
+          >
+            수업 참여
+          </button>
+        </div>
+
+        <div className="relative">
+          <button
+            onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+            className="w-32 h-10 rounded-lg border border-gray-700 bg-white flex items-center justify-between px-3"
+          >
+            <span className="text-sm text-gray-600">{selectedSort}</span>
+            <ChevronDown
+              className={`w-5 h-5 text-gray-600 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {isDropdownOpen && (
+            <div className="absolute top-full right-0 mt-1 w-32 bg-white border rounded-lg shadow-lg z-10">
+              <button
+                onClick={() => handleSortSelect('최신순')}
+                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50"
+              >
+                최신순
+              </button>
+              <button
+                onClick={() => handleSortSelect('오래된순')}
+                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50"
+              >
+                오래된순
+              </button>
+              <button
+                onClick={() => handleSortSelect('이름순')}
+                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50"
+              >
+                이름순
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {activeTab === 'create' && <CreatedClassesView classes={mockCreatedClasses} />}
+        {activeTab === 'join' && <JoinedClassesView classes={mockJoinedClasses} />}
+      </div>
+    </div>
+  );
+};
+
+export default MyPageReportBox;

--- a/src/components/mypage/MyPageReportView.tsx
+++ b/src/components/mypage/MyPageReportView.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
+import MyPageReportBox from './MyPageReportBox'; // 👈 1. 컴포넌트 import
 
-const MyPageRightPanel: React.FC = () => {
+const MyPageReportView: React.FC = () => {
   return (
-    <div className="flex-1 h-[900px] rounded-2xl border border-gray-200 bg-white shadow-md px-8 py-6">
-      <h1 className="text-black font-semibold text-[25px] mb-4">선생님 리포트</h1>
-
-      {/* 수업 생성 패널 */}
-      <div className="h-[360px] border rounded-lg bg-gray-50"></div>
-
-      {/* 수업 참여 패널 */}
-      <h2 className="font-semibold text-[25px] text-gray-800 py-4">학생 리포트</h2>
-      <div className="p-6 h-[360px] border rounded-lg bg-gray-50"></div>
+    <div className="flex-1 h-[900px] rounded-2xl border border-gray-200 bg-white shadow-md p-8">
+      {/* 👇 2. 컴포넌트를 여기에 렌더링합니다. */}
+      <MyPageReportBox />
     </div>
   );
 };
 
-export default MyPageRightPanel;
+export default MyPageReportView;

--- a/src/components/mypage/index.ts
+++ b/src/components/mypage/index.ts
@@ -10,3 +10,4 @@ export { default as MyPageBoxClass } from './MyPageBoxClass';
 export { default as MyPageComponentReport } from './MyPageComponentReport';
 export { default as MyPageComponentProblem } from './MyPageComponentProblem';
 export { default as ProblemManagementComponent } from './ProblemManagementComponent';
+export { default as MyPageReportBox } from './MyPageReportBox';


### PR DESCRIPTION
마이페이지에서 리포트 뷰에 조건부 렌더링을 넣어 수업 생성 했을 때 리포트와, 수업 참여 했을 때 리포트를 버튼으로 구분해놨습니다.
계정관리 뷰에선 프로필 구간을 삭제했습니다.
현재 보이는 문제 카드는 모두 가짜 데이터입니다.
기능 구현때는 가짜 데이터 모두 삭제 바랍니다.