### PR TITLE
fix(#166): 타이머 새로고침 문제 해결

### DIFF
--- a/src/components/student-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/student-class/EditorPanel/EditorPanel.tsx
@@ -19,7 +19,7 @@ interface EditorPanelProps {
   onCodeChange: (value: string | undefined) => void;
   studentName?: string;
   disabled?: boolean;
-  otherCursor?: { lineNumber: number; column: number } | null;
+  otherCursor?: { lineNumber: number; column: number; problemId: number | null } | null;
   onCursorChange?: (position: {
     lineNumber: number;
     column: number;
@@ -145,7 +145,7 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
             className={`px-3 py-1 rounded transition ${showOverlay ? 'bg-blue-600 text-white' : 'bg-slate-700 text-slate-200 hover:bg-slate-600'}`}
             onClick={() => setShowOverlay((v) => !v)}
           >
-            {showOverlay ? '그림판 숨기기' : '그림판 보기'}
+            {showOverlay ? '그림판 끄기' : '그림판 보기'}
           </button>
         </div>
       </div>

--- a/src/pages/TeacherClassPage.tsx
+++ b/src/pages/TeacherClassPage.tsx
@@ -579,6 +579,7 @@ const TeacherClassPage: React.FC = () => {
         onToggleClass={handleToggleClass}
         title={currentRoom?.title || '수업 제목'}
         onVoiceChatToggle={() => setIsVoiceChatOpen(!isVoiceChatOpen)}
+        roomId={roomId}
       />
 
       {/* 음성채팅 팝업 */}


### PR DESCRIPTION
구현된 기능:
1. LocalStorage 기반 타이머
방별 독립적 저장: class_timer_${roomId} 키로 구분
새로고침 복원: 시작 시간을 저장해서 경과 시간 계산
자동 정리: 수업 종료 시 LocalStorage에서 제거
2. 동작 흐름
```
수업 시작 → LocalStorage에 시작 시간 저장 → 실시간 카운트
새로고침 → LocalStorage에서 경과 시간 계산 → 정확한 타이머 복원
수업 종료 → LocalStorage 정리 + 기존 리포트 로직 그대로 사용
```
++ 학생 editorpanel의 빨간줄 해결 + 그림판 숨기기 -> 끄기로 변경 해 버튼 크기 유지되게 수정