### PR TITLE
fix(#168): 리포트 페이지 자잘한 수정

### DIFF
--- a/src/components/report/BoardReportBox.tsx
+++ b/src/components/report/BoardReportBox.tsx
@@ -4,6 +4,7 @@ import DonutChart from './DonutChart';
 export interface CategoryData {
   name: string;
   count: number; // 정답률 (successRate)
+  successRate?: number; // 정답률 (명시적)
   passedCount?: number; // 맞춘 개수
   totalCount?: number; // 총 제출 개수
   uniqueProblems?: number; // 고유 문제 수
@@ -58,13 +59,10 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
 }) => {
   const [activeChart, setActiveChart] = useState<'category' | 'problem'>('category');
 
-  // 실제 데이터가 있으면 사용하고, 없으면 기본값 사용
-  const actualCategoryData =
-    categoryData && categoryData.length > 0 ? categoryData : defaultCategoryData;
+  // 실제 데이터가 있으면 사용하고, 정말 없을 때만 기본값 사용
+  const actualCategoryData = categoryData && categoryData.length > 0 ? categoryData : undefined;
   const actualProblemAnalysisData =
-    problemAnalysisData && problemAnalysisData.length > 0
-      ? problemAnalysisData
-      : defaultProblemAnalysisData;
+    problemAnalysisData && problemAnalysisData.length > 0 ? problemAnalysisData : undefined;
 
   const handleCategoryClick = () => {
     setActiveChart('category');
@@ -79,18 +77,18 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
   // 차트 데이터 변환
   const chartData =
     activeChart === 'category'
-      ? actualCategoryData.map((item, index) => ({
+      ? (actualCategoryData || defaultCategoryData).map((item, index) => ({
           name: item.name,
           count: item.count,
           color: categoryColors[index % categoryColors.length],
         }))
-      : actualProblemAnalysisData.map((item, index) => ({
+      : (actualProblemAnalysisData || defaultProblemAnalysisData).map((item, index) => ({
           name: item.name,
           count: item.count,
           color: problemColors[index % problemColors.length],
         }));
 
-  const chartTitle = activeChart === 'category' ? '카테고리별 성과' : '학생별 정답률';
+  const chartTitle = activeChart === 'category' ? '카테고리별 성과' : '문제 분석';
 
   return (
     <div className={`w-full ${className}`}>
@@ -117,37 +115,43 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
 
             {/* Category list */}
             <div className="absolute left-6 top-[74px] space-y-5">
-              {actualCategoryData.map((category, index) => (
-                <div
-                  key={index}
-                  className="flex justify-between items-center w-[542px] max-w-[calc(100vw-120px)]"
-                >
-                  <span
-                    className="text-white text-base font-normal leading-6"
-                    style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
+              {actualCategoryData ? (
+                actualCategoryData.map((category, index) => (
+                  <div
+                    key={index}
+                    className="flex justify-between items-center w-[542px] max-w-[calc(100vw-120px)]"
                   >
-                    {category.name}
-                  </span>
-                  <div className="flex items-center space-x-2">
                     <span
-                      className="text-white text-base font-bold leading-6"
+                      className="text-white text-base font-normal leading-6"
                       style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
                     >
-                      {category.count}%
+                      {category.name}
                     </span>
-                    {category.passedCount !== undefined && category.totalCount !== undefined && (
+                    <div className="flex items-center space-x-2">
                       <span
-                        className="text-slate-300 text-sm font-medium"
+                        className="text-white text-base font-bold leading-6"
                         style={{
                           fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
                         }}
                       >
-                        ({category.passedCount}/{category.totalCount})
+                        {category.successRate !== undefined ? `${category.successRate}%` : '0%'}
                       </span>
-                    )}
+                      {category.passedCount !== undefined && category.totalCount !== undefined && (
+                        <span
+                          className="text-slate-300 text-sm font-medium"
+                          style={{
+                            fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
+                          }}
+                        >
+                          ({category.passedCount}/{category.totalCount})
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))
+              ) : (
+                <div className="text-slate-400 text-base">카테고리 데이터가 없습니다</div>
+              )}
             </div>
           </div>
 
@@ -165,38 +169,46 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
               className="absolute left-6 top-6 text-white text-2xl font-bold leading-9"
               style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
             >
-              학생별 정답률
+              문제 분석
             </div>
 
             {/* Problem analysis list */}
             <div className="absolute left-6 top-[74px] space-y-5">
-              {actualProblemAnalysisData.map((problem, index) => (
-                <div
-                  key={index}
-                  className="flex justify-between items-center w-[542px] max-w-[calc(100vw-120px)]"
-                >
-                  <span
-                    className="text-white text-base font-normal leading-6"
-                    style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
+              {actualProblemAnalysisData ? (
+                actualProblemAnalysisData.map((problem, index) => (
+                  <div
+                    key={index}
+                    className="flex justify-between items-center w-[542px] max-w-[calc(100vw-120px)]"
                   >
-                    {problem.name}
-                  </span>
-                  <div className="flex items-center space-x-1">
                     <span
-                      className="text-white text-base font-bold leading-6"
+                      className="text-white text-base font-normal leading-6"
                       style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
                     >
-                      {problem.count}
+                      {problem.name}
                     </span>
-                    <span
-                      className="text-white text-base font-bold leading-6"
-                      style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
-                    >
-                      개
-                    </span>
+                    <div className="flex items-center space-x-1">
+                      <span
+                        className="text-white text-base font-bold leading-6"
+                        style={{
+                          fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
+                        }}
+                      >
+                        {problem.count}
+                      </span>
+                      <span
+                        className="text-white text-base font-bold leading-6"
+                        style={{
+                          fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
+                        }}
+                      >
+                        개
+                      </span>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))
+              ) : (
+                <div className="text-slate-400 text-base">문제 분석 데이터가 없습니다</div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/report/BoardReportStudent.tsx
+++ b/src/components/report/BoardReportStudent.tsx
@@ -125,11 +125,11 @@ const BoardReportStudent: React.FC<BoardReportStudentProps> = ({
         </div>
       )}
 
-      {/* 학생용 뷰에서는 학생 이름만 표시 */}
+      {/* 학생용 뷰에서는 학생 이름과 통계를 패널로 표시 */}
       {isStudentView && (
-        <div className="mb-5">
+        <div className="mb-5 p-4 bg-slate-700 border border-slate-600 rounded-xl">
           <h2 className="text-white text-xl font-bold">{selectedStudent}</h2>
-          <p className="text-slate-400 text-sm mt-1">
+          <p className="text-white text-sm mt-1">
             해결한 문제: {solvedProblems}/{totalProblems}
           </p>
         </div>
@@ -145,7 +145,7 @@ const BoardReportStudent: React.FC<BoardReportStudentProps> = ({
               onClick={() => onProblemSelect?.(problem)}
               className={`p-4 rounded-xl cursor-pointer transition-all duration-200 ${
                 selectedProblem?.problemId === problem.problemId
-                  ? 'bg-blue-600 border-2 border-blue-400'
+                  ? 'bg-[#221F34] border-4 border-green-300'
                   : 'bg-[#221F34] hover:bg-[#2A2640] border border-slate-600'
               }`}
             >

--- a/src/components/report/BoxReportStudent.tsx
+++ b/src/components/report/BoxReportStudent.tsx
@@ -63,7 +63,7 @@ const SmileIcon: React.FC = () => (
   <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="M24.8 24.8H24.824M39.2 24.8H39.224M56 32C56 45.2548 45.2548 56 32 56C18.7452 56 8 45.2548 8 32C8 18.7452 18.7452 8 32 8C45.2548 8 56 18.7452 56 32ZM46.4 34.4C45.8274 37.7898 44.0609 40.8629 41.4198 43.0638C38.7788 45.2646 35.4375 46.448 32 46.4C28.5625 46.448 25.2212 45.2646 22.5802 43.0638C19.9391 40.8629 18.1726 37.7898 17.6 34.4H46.4Z"
-      stroke="#C7AFFF"
+      stroke="#A7F3D0"
       strokeWidth="4"
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -75,7 +75,7 @@ const FrownIcon: React.FC = () => (
   <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="M41.6 41.6C41.6 41.6 38 36.8 32 36.8C26 36.8 22.4 41.6 22.4 41.6M24.8 24.8H24.824M39.2 24.8H39.224M56 32C56 45.2548 45.2548 56 32 56C18.7452 56 8 45.2548 8 32C8 18.7452 18.7452 8 32 8C45.2548 8 56 18.7452 56 32Z"
-      stroke="#F3DEBB"
+      stroke="#FECACA"
       strokeWidth="4"
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -104,16 +104,16 @@ const MetricCard: React.FC<{ metric: StudentMetric }> = ({ metric }) => {
         };
       case 'bestCategory':
         return {
-          gradient: 'bg-gradient-to-r from-violet-600 to-violet-500',
-          shadow: 'shadow-[0px_8px_30px_0px_rgba(139,92,246,0.20)]',
+          gradient: 'bg-gradient-to-r from-amber-600 to-amber-500',
+          shadow: 'shadow-[0px_8px_30px_0px_rgba(245,158,11,0.20)]',
           icon: <SmileIcon />,
           titleSize: 'text-base',
           valueSize: 'text-3xl',
         };
       case 'worstCategory':
         return {
-          gradient: 'bg-gradient-to-r from-amber-600 to-amber-500',
-          shadow: 'shadow-[0px_8px_30px_0px_rgba(245,158,11,0.20)]',
+          gradient: 'bg-gradient-to-r from-violet-600 to-violet-500',
+          shadow: 'shadow-[0px_8px_30px_0px_rgba(139,92,246,0.20)]',
           icon: <FrownIcon />,
           titleSize: 'text-base',
           valueSize: 'text-3xl',
@@ -171,9 +171,11 @@ const BoxReportStudent: React.FC<BoxReportStudentProps> = ({
   className = '',
 }) => {
   return (
-    <div className={`grid grid-cols-2 xl:grid-cols-4 gap-4 xl:gap-6 w-full ${className}`}>
+    <div className={`flex flex-wrap gap-4 xl:gap-6 w-full ${className}`}>
       {metrics.map((metric, index) => (
-        <MetricCard key={`${metric.type}-${index}`} metric={metric} />
+        <div key={`${metric.type}-${index}`} className="flex-1 min-w-[250px] max-w-[400px]">
+          <MetricCard metric={metric} />
+        </div>
       ))}
     </div>
   );

--- a/src/components/report/StudentReportDashboardView.tsx
+++ b/src/components/report/StudentReportDashboardView.tsx
@@ -38,7 +38,7 @@ const StudentReportDashboardView: React.FC<StudentReportDashboardViewProps> = ({
 
   // 탭 컴포넌트
   const tabs = (
-    <div className="flex gap-4">
+    <div className="flex gap-2">
       <button
         onClick={() => setActiveTab('dashboard')}
         className={`px-6 py-2 rounded-lg text-sm font-medium transition-colors ${
@@ -67,9 +67,15 @@ const StudentReportDashboardView: React.FC<StudentReportDashboardViewProps> = ({
     <>
       <button
         onClick={() => console.log('리포트 저장')}
-        className="flex items-center justify-center gap-2 px-5 py-3 bg-gradient-to-r from-emerald-600 to-emerald-700 rounded-md text-white font-medium"
+        className="flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-emerald-600 to-emerald-700 rounded-md text-white font-medium"
       >
         <Save className="w-5 h-5" /> 리포트 저장
+      </button>
+      <button
+        onClick={() => console.log('수업 나가기')}
+        className="flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-red-600 to-red-700 rounded-md text-white font-medium"
+      >
+        <LogOut className="w-5 h-5" /> 수업 나가기
       </button>
     </>
   );

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -4,7 +4,6 @@ import { useReportStore } from '../store/reportStore';
 import { useTeacherStore } from '../store/teacherStore';
 import ReportLayout from '../components/report/ReportLayout';
 import OverallReportView from '../components/report/OverallReportView';
-import ProblemReportView from '../components/report/ProblemReportView';
 import StudentReportView from '../components/report/StudentReportView';
 import { LogOut, Save } from 'lucide-react';
 import { showConfirm, showToast } from '../utils/sweetAlert';
@@ -13,7 +12,7 @@ const ReportPage: React.FC = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
 
-  const [activeView, setActiveView] = useState<'overall' | 'problem' | 'student'>('overall');
+  const [activeView, setActiveView] = useState<'overall' | 'student'>('overall');
 
   const { deleteRoom, isLoading } = useTeacherStore();
   const { reportData, fetchReport } = useReportStore();
@@ -134,9 +133,6 @@ const ReportPage: React.FC = () => {
       <button onClick={() => setActiveView('student')} className={getButtonClass('student')}>
         학생 리포트
       </button>
-      <button onClick={() => setActiveView('problem')} className={getButtonClass('problem')}>
-        문제 리포트
-      </button>
     </>
   );
 
@@ -192,8 +188,6 @@ const ReportPage: React.FC = () => {
           studentChartData={studentChartData}
         />
       )}
-      {activeView === 'problem' && <ProblemReportView />}
-
       {activeView === 'student' && (
         <StudentReportView
           studentResults={studentData}

--- a/src/pages/StudentReportPage.tsx
+++ b/src/pages/StudentReportPage.tsx
@@ -88,7 +88,8 @@ const StudentReportPage = () => {
   // 카테고리 데이터
   const categoryData = (reportData as any)?.categoryAnalysis?.map((category: any) => ({
     name: category.name,
-    count: category.successRate, // 카테고리별 정답률
+    count: category.uniqueProblems || 0, // 카테고리별 문제 수
+    successRate: category.successRate, // 정답률은 별도 보관
     passedCount: category.passedSubmissions, // 맞춘 개수
     totalCount: category.totalSubmissions, // 총 제출 개수
     uniqueProblems: category.uniqueProblems, // 고유 문제 수


### PR DESCRIPTION
close #168 

1. 학생 리포트와 선생님 리포트 박스 색깔 순서 맞추기  
2. 학생 리포트 페이지 대시보드랑 상세분석 버튼 간격 줄이기 
3. 학생 리포트 페이지 수업 종료 버튼 추가 
4. 학생 리포트 페이지 문제 클릭했을 때 색 바꾸기 
5. 학생 이름 + 해결한 문제 나오는 부분 좀 더 잘 보이게 박스로 묶기 
6. 도넛 차트 하나만 있어도 차트 나오게 하기 
7. 선생님 리포트 페이지 문제 리포트 기능 삭제