### PR TITLE
fix(#186):레이어 지우기 버튼 오류 해결

### DIFF
--- a/src/components/common/SvgOverlay.tsx
+++ b/src/components/common/SvgOverlay.tsx
@@ -96,17 +96,23 @@ const SvgOverlay: React.FC<SVGOverlayProps> = ({
   };
 
   return (
-    <>
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none', // 컨테이너 자체는 이벤트 없음
+        zIndex: 10,
+      }}
+    >
       <svg
         ref={svgRef}
         style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
           width: '100%',
           height: '100%',
-          pointerEvents: svgPointerEvents,
-          zIndex: 10,
+          pointerEvents: readOnly ? 'none' : 'auto',
         }}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
@@ -136,11 +142,11 @@ const SvgOverlay: React.FC<SVGOverlayProps> = ({
         <div
           style={{
             position: 'absolute',
-            top: 16, // 에디터 헤더 바로 아래
-            right: 16, // 오른쪽에 붙임
+            top: 16,
+            right: 16,
             display: 'flex',
             gap: 8,
-            pointerEvents: 'auto',
+            pointerEvents: 'auto', // 버튼 영역만 이벤트 허용
             zIndex: 9999,
             backgroundColor: 'rgba(30, 30, 30, 0.9)',
             padding: '8px',
@@ -204,7 +210,7 @@ const SvgOverlay: React.FC<SVGOverlayProps> = ({
           </button>
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/common/VoiceChatModal.tsx
+++ b/src/components/common/VoiceChatModal.tsx
@@ -192,7 +192,7 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
 
       {/* 모달은 조건부 렌더링 */}
       {isOpen && (
-        <div className="fixed top-16 right-6 bg-slate-800 rounded-lg p-4 w-80 shadow-lg border border-slate-600 z-50">
+        <div className="fixed top-16 right-6 bg-slate-800 rounded-lg p-4 w-80 shadow-lg border border-slate-600 z-[99999]">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-bold text-white">음성채팅 설정</h3>
             <button onClick={onClose} className="text-slate-400 hover:text-white transition-colors">


### PR DESCRIPTION
### 1. 음성채팅 모달(VoiceChatModal) z-index 상향
**설명:**  
음성채팅 모달이 다른 모든 UI(그림판, 버튼, 분석패널 등) 위에 항상 최상위로 표시되도록,  
Tailwind CSS의 기본 z-50(z-index: 9999)에서 z-[99999]로 z-index 값을 올렸습니다.  
이제 음성채팅 모달이 어떤 상황에서도 가려지지 않고 항상 맨 위에 뜹니다.

---

### 2. 그림판 팔레트(색상/지우기 버튼) 클릭 이벤트 분리
**설명:**  
그림판 SVG(드로잉 레이어)와 팔레트/지우기 버튼이 서로 겹쳐서 클릭 이벤트가 섞이던 문제를 해결했습니다.  
SVG와 버튼을 하나의 absolute 컨테이너(div) 안에 형제 요소로 분리하여,  
- 그림판 영역에서는 SVG만 이벤트를 받고  
- 버튼 위에서는 버튼만 이벤트를 받도록  
구조를 리팩토링했습니다.  
이제 그림판 아무 곳을 클릭해도 버튼이 클릭되지 않고,  
버튼 위에서만 정상적으로 동작합니다.