### PR TITLE
fix: 학생 정답률, 문제별 정답률 로직 수정

### DIFF
--- a/src/components/report/BoardReportBox.tsx
+++ b/src/components/report/BoardReportBox.tsx
@@ -52,7 +52,6 @@ const problemColors = [
 const BoardReportBox: React.FC<BoardReportBoxProps> = ({
   categoryData,
   problemAnalysisData,
-
   onCategoryClick,
   onProblemClick,
   className = '',
@@ -74,21 +73,29 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
     onProblemClick?.();
   };
 
-  // 차트 데이터 변환
-  const chartData =
-    activeChart === 'category'
-      ? (actualCategoryData || defaultCategoryData).map((item, index) => ({
-          name: item.name,
-          count: item.count,
-          color: categoryColors[index % categoryColors.length],
-        }))
-      : (actualProblemAnalysisData || defaultProblemAnalysisData).map((item, index) => ({
-          name: item.name,
-          count: item.count,
-          color: problemColors[index % problemColors.length],
-        }));
+  // 카테고리별 문제 수 비율 차트 데이터 변환
+  const categoryProblemCountData = (actualCategoryData || defaultCategoryData).map(
+    (item, index) => ({
+      name: item.name,
+      count: item.uniqueProblems ?? (item.problemTitles ? item.problemTitles.length : 0),
+      color: categoryColors[index % categoryColors.length],
+    }),
+  );
 
-  const chartTitle = activeChart === 'category' ? '카테고리별 성과' : '문제 분석';
+  // 기존 문제 분석 차트 데이터
+  const problemAnalysisChartData = (actualProblemAnalysisData || defaultProblemAnalysisData).map(
+    (item, index) => ({
+      name: item.name,
+      count: item.count,
+      color: problemColors[index % problemColors.length],
+    }),
+  );
+
+  // 차트 데이터 및 타이틀
+  const chartData =
+    activeChart === 'category' ? categoryProblemCountData : problemAnalysisChartData;
+
+  const chartTitle = activeChart === 'category' ? '카테고리별 문제 수 비율' : '문제 분석';
 
   return (
     <div className={`w-full ${className}`}>
@@ -110,7 +117,7 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
               className="absolute left-6 top-6 text-white text-2xl font-bold leading-9"
               style={{ fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif' }}
             >
-              카테고리별 성과
+              카테고리 분류
             </div>
 
             {/* Category list */}
@@ -127,25 +134,24 @@ const BoardReportBox: React.FC<BoardReportBoxProps> = ({
                     >
                       {category.name}
                     </span>
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center space-x-1">
                       <span
                         className="text-white text-base font-bold leading-6"
                         style={{
                           fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
                         }}
                       >
-                        {category.successRate !== undefined ? `${category.successRate}%` : '0%'}
+                        {category.uniqueProblems ??
+                          (category.problemTitles ? category.problemTitles.length : 0)}
                       </span>
-                      {category.passedCount !== undefined && category.totalCount !== undefined && (
-                        <span
-                          className="text-slate-300 text-sm font-medium"
-                          style={{
-                            fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
-                          }}
-                        >
-                          ({category.passedCount}/{category.totalCount})
-                        </span>
-                      )}
+                      <span
+                        className="text-white text-base font-bold leading-6"
+                        style={{
+                          fontFamily: 'Inter, -apple-system, Roboto, Helvetica, sans-serif',
+                        }}
+                      >
+                        개
+                      </span>
                     </div>
                   </div>
                 ))

--- a/src/components/report/StudentReportDashboardView.tsx
+++ b/src/components/report/StudentReportDashboardView.tsx
@@ -12,6 +12,7 @@ import StudentReportView from './StudentReportView';
 import { saveReport } from '../../api/reportApi';
 import { showToast } from '../../utils/sweetAlert';
 import { showConfirm } from '../../utils/sweetAlert';
+import DonutChart from './DonutChart';
 
 interface StudentReportDashboardViewProps {
   roomTitle?: string;
@@ -193,12 +194,8 @@ const StudentReportDashboardView: React.FC<StudentReportDashboardViewProps> = ({
               <BoxReportStudent metrics={studentMetrics} className="mb-8" />
             </section>
 
-            {/* 카테고리 및 문제 분석 보드 */}
+            {/* 카테고리 분류 보드 제거, BoardReportBox만 남김 */}
             <section>
-              <div className="mb-6">
-                <h2 className="text-2xl font-bold text-white mb-2">상세 분석</h2>
-                <p className="text-slate-400">카테고리별 성과와 문제 해결 패턴을 분석합니다</p>
-              </div>
               <BoardReportBox
                 categoryData={categoryData}
                 problemAnalysisData={problemAnalysisData}

--- a/src/pages/StudentReportPage.tsx
+++ b/src/pages/StudentReportPage.tsx
@@ -76,81 +76,75 @@ const StudentReportPage = () => {
       ]
     : undefined;
 
-  // 문제 분석 데이터 (실제 submission 데이터에서 생성)
+  // 전체 문제 목록 추출 (problems 필드 기반)
+  const allProblems: any[] = (reportData as any)?.problems || [];
+
+  // 카테고리별 문제 개수 집계 (모든 문제 기준)
+  const categoryData = React.useMemo(() => {
+    if (!allProblems || allProblems.length === 0) {
+      console.log('allProblems is empty:', allProblems);
+      return [];
+    }
+    const categoryMap: { [category: string]: Set<number> } = {};
+    allProblems.forEach((problem: any) => {
+      if (problem.categories && Array.isArray(problem.categories)) {
+        problem.categories.forEach((cat: string) => {
+          if (!categoryMap[cat]) categoryMap[cat] = new Set();
+          categoryMap[cat].add(problem.problemId);
+        });
+      }
+    });
+    const result = Object.entries(categoryMap).map(([name, problemSet]) => ({
+      name,
+      count: problemSet.size,
+      uniqueProblems: problemSet.size,
+      problemTitles: Array.from(problemSet).map(
+        (id) => allProblems.find((p) => p.problemId === id)?.title || '',
+      ),
+    }));
+    console.log('categoryData:', result);
+    return result;
+  }, [allProblems]);
+
+  // 문제 분석 데이터 (미제출 포함, 모든 문제 기준)
   const problemAnalysisData = React.useMemo(() => {
     if (!reportData || !user?.name) return undefined;
-
     const allSubmissions = (reportData as any).submissions || [];
     const userSubmissions = allSubmissions.filter(
       (submission: any) => submission.user?.name === user.name,
     );
+    const submittedProblemIds = new Set(userSubmissions.map((sub: any) => sub.problem?.problemId));
+    const unsubmittedProblems = allProblems.filter(
+      (problem: any) => !submittedProblemIds.has(problem.problemId),
+    );
 
-    // 통과/실패 분류
+    // 기존 분석 로직
     const passedCount = userSubmissions.filter((sub: any) => sub.is_passed).length;
     const failedSubmissions = userSubmissions.filter((sub: any) => !sub.is_passed);
-
-    // 실패한 제출들의 stdout 값들을 수집하고 그룹핑
     const stdoutGroups: { [key: string]: number } = {};
-
     failedSubmissions.forEach((submission: any) => {
       let stdout = submission.stdout || '알 수 없는 오류';
-
-      // stdout이 너무 길면 첫 줄만 사용 (에러의 핵심 부분)
       const firstLine = stdout.split('\n')[0].trim();
-      if (firstLine.length > 0) {
-        stdout = firstLine;
-      }
-
-      // 너무 긴 메시지는 줄임 (50자 제한)
-      if (stdout.length > 50) {
-        stdout = stdout.substring(0, 50) + '...';
-      }
-
-      // 빈 stdout는 '실행 오류'로 처리
-      if (!stdout || stdout.trim() === '') {
-        stdout = '실행 오류';
-      }
-
+      if (firstLine.length > 0) stdout = firstLine;
+      if (stdout.length > 50) stdout = stdout.substring(0, 50) + '...';
+      if (!stdout || stdout.trim() === '') stdout = '실행 오류';
       stdoutGroups[stdout] = (stdoutGroups[stdout] || 0) + 1;
     });
-
-    // 결과 배열 생성 (통과 + 실패 원인들)
     const result = [];
-
-    // 통과한 경우 추가
     if (passedCount > 0) {
-      result.push({
-        name: '통과',
-        count: passedCount,
-      });
+      result.push({ name: '통과', count: passedCount });
     }
-
-    // 실패 원인들을 개수 순으로 정렬해서 추가 (최대 5개)
     const failedReasons = Object.entries(stdoutGroups)
-      .sort(([, countA], [, countB]) => countB - countA) // 개수가 많은 순으로 정렬
-      .slice(0, 5) // 최대 5개만
-      .map(([reason, count]) => ({
-        name: reason,
-        count: count,
-      }));
-
+      .sort(([, countA], [, countB]) => countB - countA)
+      .slice(0, 5)
+      .map(([reason, count]) => ({ name: reason, count }));
     result.push(...failedReasons);
-
+    // 미제출 문제 추가
+    if (unsubmittedProblems.length > 0) {
+      result.push({ name: '미제출', count: unsubmittedProblems.length });
+    }
     return result.length > 0 ? result : undefined;
-  }, [reportData, user?.name]);
-
-  // 카테고리 데이터
-  const categoryData = (reportData as any)?.categoryAnalysis?.map((category: any) => ({
-    name: category.name,
-    count: category.uniqueProblems || 0, // 카테고리별 문제 수
-    successRate: category.successRate, // 정답률은 별도 보관
-    passedCount: category.passedSubmissions, // 맞춘 개수
-    totalCount: category.totalSubmissions, // 총 제출 개수
-    uniqueProblems: category.uniqueProblems, // 고유 문제 수
-    problemTitles: category.problemTitles, // 포함된 문제들
-    participatingStudents: category.participatingStudents, // 참여 학생 수
-    firstSubmissionSuccessRate: category.firstSubmissionSuccessRate, // 첫 제출 성공률
-  }));
+  }, [reportData, user?.name, allProblems]);
 
   // 문제 분석 데이터 (학생별 정답률 데이터 활용) - 이전 코드 제거
 


### PR DESCRIPTION
1. 학생 정답률, 문제별 정답률 구현됐습니다.
2. 평균 제출시간에서 한번에 제출해서 맞힌 문제로 변경하고 선생님이 제출한 경우는 제외했습니다.
3. 카테고리 분류로 바꾸고 이제 정확하게 카테고리 표현됩니다.
4. 문제 분석에서 어떻게 된거지 잘 나오고 미제출도 추가됩니다. 
5. 이 모든게 마이페이지 리포트에 적용됩니다.