### PR TITLE
fix: 문제 패널 클릭시 코드 뷰 닫히게 개선

### DIFF
--- a/src/components/report/BoardReportStudentSubmission.tsx
+++ b/src/components/report/BoardReportStudentSubmission.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export interface SubmissionData {
   id: string | number;
@@ -24,6 +24,11 @@ const BoardReportStudentSubmission: React.FC<BoardReportStudentSubmissionProps> 
   className = '',
 }) => {
   const [selectedSubmission, setSelectedSubmission] = useState<SubmissionData | null>(null);
+
+  // submissions prop이 바뀔 때마다 코드 뷰를 닫는다
+  useEffect(() => {
+    setSelectedSubmission(null);
+  }, [submissions]);
 
   // 제출 결과의 간단한 표시 메시지
   const getSimpleStatusMessage = (submission: SubmissionData): string => {

--- a/src/pages/SavedReportDetailPage.tsx
+++ b/src/pages/SavedReportDetailPage.tsx
@@ -123,6 +123,7 @@ const SavedReportDetailPage = () => {
     { name: '실패', count: failedCount },
     { name: '미제출', count: unsubmittedProblems.length },
   ];
+  console.log('problemAnalysisData:', problemAnalysisData);
 
   const studentMetrics = reportData
     ? [


### PR DESCRIPTION
제목이 곧 내용입니다.

문제 패널을 클릭하면 코드뷰가 안닫히는 버그가 있었는데 수정해서 누르면 자동으로 닫히고 
해당 코드의 제출 내역이 보게 수정되었습니다.