### PR TITLE
fix(#219): 다른 라인 동시편집

### DIFF
--- a/src/components/student-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/student-class/EditorPanel/EditorPanel.tsx
@@ -6,12 +6,24 @@ import Editor from '@monaco-editor/react';
 import usersIcon from '../../../assets/usersIcon.svg';
 import SvgOverlay from '../../common/SvgOverlay';
 import * as monaco from 'monaco-editor';
-import {
-  diff_match_patch as DiffMatchPatch,
-  DIFF_DELETE,
-  DIFF_INSERT,
-  DIFF_EQUAL,
-} from 'diff-match-patch';
+
+function mergeByLine(myCode: string, remoteCode: string, myLine: number | null): string {
+  const myLines = myCode.split('\n');
+  const remoteLines = remoteCode.split('\n');
+  // “라인 개수 다르면 remote 기준으로 덮어씀”
+  if (myLines.length !== remoteLines.length) {
+    return remoteCode; // 보수적 처리 (꼬일 바에야 remote로 맞춰버림)
+  }
+  const result: string[] = [];
+  for (let i = 0; i < myLines.length; ++i) {
+    if (myLine !== null && i === myLine - 1) {
+      result.push(myLines[i] ?? '');
+    } else {
+      result.push(remoteLines[i] ?? '');
+    }
+  }
+  return result.join('\n');
+}
 
 interface SVGLine {
   points: [number, number][];
@@ -157,88 +169,38 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
 
     // 커서/스크롤 백업
     const prevSel = editorRef.current.getSelections();
-    const prevScroll = editorRef.current.getScrollTop();
 
     isRemoteUpdating.current = true;
     model.setValue(newText); // 전체 세팅
     editorRef.current.setSelections(prevSel || []);
-    editorRef.current.setScrollTop(prevScroll);
     isRemoteUpdating.current = false;
-  }, [problemId, code]);
+  }, [problemId]);
 
-  // 네트워크로부터 내려온 code prop 변경 감지용
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
     const model = editor.getModel();
     if (!model) return;
 
-    const newText = normalizeEOL(code || '');
+    const remoteCode = normalizeEOL(code ?? '');
+    const myCode = normalizeEOL(model.getValue());
+    if (myCode === remoteCode) return;
 
-    const oldText = normalizeEOL(model.getValue());
-    if (oldText === newText) {
-      return;
+    // === 커서 위치 백업 ===
+    const prevPosition = editor.getPosition();
+
+    // 병합
+    const myLine = prevPosition ? prevPosition.lineNumber : null;
+    const merged = mergeByLine(myCode, remoteCode, myLine);
+
+    isRemoteUpdating.current = true;
+    model.setValue(merged);
+    // === 복구 ===
+    if (prevPosition) {
+      editor.setPosition(prevPosition);
+      editor.revealPositionInCenter(prevPosition); // 옵션
     }
-
-    // 1) diff 계산
-    const dmp = new DiffMatchPatch();
-    dmp.Diff_Timeout = 0;
-    const diffs = dmp.diff_main(oldText, newText);
-    dmp.diff_cleanupEfficiency(diffs);
-
-    // === (핵심) 오프셋 기반으로 변환 ===
-    let oldIdx = 0;
-    const edits: monaco.editor.IIdentifiedSingleEditOperation[] = [];
-
-    for (const [op, text] of diffs as [number, string][]) {
-      if (op === DIFF_EQUAL) {
-        oldIdx += text.length;
-        continue;
-      }
-
-      const startPos = model.getPositionAt(oldIdx);
-
-      if (op === DIFF_DELETE) {
-        const endPos = model.getPositionAt(oldIdx + text.length);
-        edits.push({
-          range: new monaco.Range(
-            startPos.lineNumber,
-            startPos.column,
-            endPos.lineNumber,
-            endPos.column,
-          ),
-          text: '',
-          forceMoveMarkers: true,
-        });
-        oldIdx += text.length;
-      } else if (op === DIFF_INSERT) {
-        // 삭제는 oldIdx 증가했지만, 삽입은 old 텍스트에서는 길이 0
-        edits.push({
-          range: new monaco.Range(
-            startPos.lineNumber,
-            startPos.column,
-            startPos.lineNumber,
-            startPos.column,
-          ),
-          text,
-          forceMoveMarkers: true,
-        });
-        // oldIdx 그대로
-      }
-    }
-
-    if (edits.length) {
-      // 3) 커서·스크롤 보존
-      const prevSelections = editor.getSelections();
-      const prevScroll = editor.getScrollTop();
-
-      isRemoteUpdating.current = true;
-      editor.pushUndoStop();
-      editor.executeEdits('remote', edits, prevSelections || []);
-      editor.pushUndoStop();
-      editor.setScrollTop(prevScroll);
-      isRemoteUpdating.current = false;
-    }
+    isRemoteUpdating.current = false;
   }, [code]);
 
   useEffect(() => {


### PR DESCRIPTION
### 실시간 협업(코드 동시편집)에서 라인 단위 머지(merge) 로직 개선

다른 라인 편집 시, 각자 수정한 라인만 반영되도록 구현

동시에 같은 라인을 편집할 경우에는 충돌 방지 차원에서 remote(상대방) 코드로 일괄 동기화

### 주요 코드
* mergeByLine 함수:

같은 라인 편집시 remote 코드로 동기화(충돌 방지)

라인 개수 다를 경우 remote 전체로 대체

```
function mergeByLine(
  myCode: string,
  remoteCode: string,
  myLine: number | null,
): string {
  const myLines = myCode.split('\n');
  const remoteLines = remoteCode.split('\n');
  if (myLines.length !== remoteLines.length) {
    return remoteCode;
  }
  const result: string[] = [];
  for (let i = 0; i < myLines.length; ++i) {
    if (myLine !== null && i === myLine - 1) {
      result.push(myLines[i] ?? '');
    } else {
      result.push(remoteLines[i] ?? '');
    }
  }
  return result.join('\n');
}
```
### 테스트/확인
서로 다른 라인 편집 시 실시간 반영 정상

같은 라인, 엔터 등 예외 상황에서 꼬임/무한루프 방지

커서 동기화/복구 정상 작동

### 간단 요약:

동시 편집 머지 정책을 “서로 다른 라인만 실시간 반영, 충돌 시 remote 우선” 으로 일원화