### PR TITLE
fix(#224): 같은 라인  동시편집 경고창 추가

### DIFF
--- a/src/components/student-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/student-class/EditorPanel/EditorPanel.tsx
@@ -78,6 +78,7 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
   const isRemoteUpdating = useRef(false);
   const normalizeEOL = (s: string = '') => s.replace(/\r\n?/g, '\n');
   const cursorPositionRef = useRef<monaco.Position | null>(null);
+  const [myCursorLine, setMyCursorLine] = useState<number | null>(null);
 
   // Editor mount에서 그림판+커서 모두 처리
   function handleEditorDidMount(editor: any) {
@@ -96,6 +97,7 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
     // 커서 위치 변경 이벤트 리스너 추가
     if (onCursorChange) {
       editor.onDidChangeCursorPosition((e: any) => {
+        setMyCursorLine(e.position.lineNumber); // 커서 이동시 업데이트!
         // 네트워크로 인한 업데이트 중엔 무시
         if (!isRemoteUpdating.current) {
           onCursorChange({
@@ -238,6 +240,12 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
       </div>
       {/* Monaco Editor + SvgOverlay */}
       <div className="flex-grow relative">
+        {otherCursor && myCursorLine !== null && otherCursor.lineNumber === myCursorLine && (
+          <div className="absolute top-2 right-4 bg-yellow-400/80 text-slate-900 px-3 py-1 rounded shadow text-xs font-bold z-30 animate-pulse">
+            동일 줄에 상대방 커서가 있습니다. 커서를 다른 곳으로 옮겨주세요. <br />
+            마지막으로 입력한 사람의 코드가 최종 반영됩니다.{' '}
+          </div>
+        )}
         <Editor
           height="100%"
           language="python"

--- a/src/components/student-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/student-class/EditorPanel/EditorPanel.tsx
@@ -6,12 +6,24 @@ import Editor from '@monaco-editor/react';
 import usersIcon from '../../../assets/usersIcon.svg';
 import SvgOverlay from '../../common/SvgOverlay';
 import * as monaco from 'monaco-editor';
-import {
-  diff_match_patch as DiffMatchPatch,
-  DIFF_DELETE,
-  DIFF_INSERT,
-  DIFF_EQUAL,
-} from 'diff-match-patch';
+
+function mergeByLine(myCode: string, remoteCode: string, myLine: number | null): string {
+  const myLines = myCode.split('\n');
+  const remoteLines = remoteCode.split('\n');
+  // “라인 개수 다르면 remote 기준으로 덮어씀”
+  if (myLines.length !== remoteLines.length) {
+    return remoteCode; // 보수적 처리 (꼬일 바에야 remote로 맞춰버림)
+  }
+  const result: string[] = [];
+  for (let i = 0; i < myLines.length; ++i) {
+    if (myLine !== null && i === myLine - 1) {
+      result.push(myLines[i] ?? '');
+    } else {
+      result.push(remoteLines[i] ?? '');
+    }
+  }
+  return result.join('\n');
+}
 
 interface SVGLine {
   points: [number, number][];
@@ -157,88 +169,38 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
 
     // 커서/스크롤 백업
     const prevSel = editorRef.current.getSelections();
-    const prevScroll = editorRef.current.getScrollTop();
 
     isRemoteUpdating.current = true;
     model.setValue(newText); // 전체 세팅
     editorRef.current.setSelections(prevSel || []);
-    editorRef.current.setScrollTop(prevScroll);
     isRemoteUpdating.current = false;
-  }, [problemId, code]);
+  }, [problemId]);
 
-  // 네트워크로부터 내려온 code prop 변경 감지용
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor) return;
     const model = editor.getModel();
     if (!model) return;
 
-    const newText = normalizeEOL(code || '');
+    const remoteCode = normalizeEOL(code ?? '');
+    const myCode = normalizeEOL(model.getValue());
+    if (myCode === remoteCode) return;
 
-    const oldText = normalizeEOL(model.getValue());
-    if (oldText === newText) {
-      return;
+    // === 커서 위치 백업 ===
+    const prevPosition = editor.getPosition();
+
+    // 병합
+    const myLine = prevPosition ? prevPosition.lineNumber : null;
+    const merged = mergeByLine(myCode, remoteCode, myLine);
+
+    isRemoteUpdating.current = true;
+    model.setValue(merged);
+    // === 복구 ===
+    if (prevPosition) {
+      editor.setPosition(prevPosition);
+      editor.revealPositionInCenter(prevPosition); // 옵션
     }
-
-    // 1) diff 계산
-    const dmp = new DiffMatchPatch();
-    dmp.Diff_Timeout = 0;
-    const diffs = dmp.diff_main(oldText, newText);
-    dmp.diff_cleanupEfficiency(diffs);
-
-    // === (핵심) 오프셋 기반으로 변환 ===
-    let oldIdx = 0;
-    const edits: monaco.editor.IIdentifiedSingleEditOperation[] = [];
-
-    for (const [op, text] of diffs as [number, string][]) {
-      if (op === DIFF_EQUAL) {
-        oldIdx += text.length;
-        continue;
-      }
-
-      const startPos = model.getPositionAt(oldIdx);
-
-      if (op === DIFF_DELETE) {
-        const endPos = model.getPositionAt(oldIdx + text.length);
-        edits.push({
-          range: new monaco.Range(
-            startPos.lineNumber,
-            startPos.column,
-            endPos.lineNumber,
-            endPos.column,
-          ),
-          text: '',
-          forceMoveMarkers: true,
-        });
-        oldIdx += text.length;
-      } else if (op === DIFF_INSERT) {
-        // 삭제는 oldIdx 증가했지만, 삽입은 old 텍스트에서는 길이 0
-        edits.push({
-          range: new monaco.Range(
-            startPos.lineNumber,
-            startPos.column,
-            startPos.lineNumber,
-            startPos.column,
-          ),
-          text,
-          forceMoveMarkers: true,
-        });
-        // oldIdx 그대로
-      }
-    }
-
-    if (edits.length) {
-      // 3) 커서·스크롤 보존
-      const prevSelections = editor.getSelections();
-      const prevScroll = editor.getScrollTop();
-
-      isRemoteUpdating.current = true;
-      editor.pushUndoStop();
-      editor.executeEdits('remote', edits, prevSelections || []);
-      editor.pushUndoStop();
-      editor.setScrollTop(prevScroll);
-      isRemoteUpdating.current = false;
-    }
+    isRemoteUpdating.current = false;
   }, [code]);
 
   useEffect(() => {

--- a/src/components/teacher-class/EditorPanel/EditorPanel.tsx
+++ b/src/components/teacher-class/EditorPanel/EditorPanel.tsx
@@ -78,6 +78,7 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
   const isRemoteUpdating = useRef(false);
   const normalizeEOL = (s: string = '') => s.replace(/\r\n?/g, '\n');
   const initialCodeRef = useRef(code); // mount 시 고정
+  const [myCursorLine, setMyCursorLine] = useState<number | null>(null);
 
   // Editor mount에서 그림판+커서 모두 처리
   function handleEditorDidMount(editor: any) {
@@ -96,6 +97,7 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
     // 커서 위치 변경 이벤트 리스너 추가
     if (onCursorChange) {
       editor.onDidChangeCursorPosition((e: any) => {
+        setMyCursorLine(e.position.lineNumber); // 커서 이동시 업데이트!
         // 네트워크로 인한 업데이트 중엔 무시
         if (!isRemoteUpdating.current) {
           onCursorChange({
@@ -221,6 +223,12 @@ const TeacherEditorPanel: React.FC<TeacherEditorPanelProps> = ({
       </div>
       {/* Monaco Editor + SvgOverlay */}
       <div className="flex-grow relative min-h-[300px]">
+        {otherCursor && myCursorLine !== null && otherCursor.lineNumber === myCursorLine && (
+          <div className="absolute top-2 right-4 bg-yellow-400/80 text-slate-900 px-3 py-1 rounded shadow text-xs font-bold z-30 animate-pulse">
+            동일 줄에 상대방 커서가 있습니다. 커서를 다른 곳으로 옮겨주세요. <br />
+            마지막으로 입력한 사람의 코드가 최종 반영됩니다.{' '}
+          </div>
+        )}
         <Editor
           height="100%"
           language="python"


### PR DESCRIPTION
## 변경 사항
동일 라인(줄)에 상대방 커서가 있을 때 안내 메시지 표시

내 커서와 상대방(otherCursor)이 같은 줄(lineNumber)에 있을 때,
에디터 우측 상단에 노란색 안내 문구가 뜨도록 UI 추가

* 안내 문구 예시:
```
동일 줄에 상대방 커서가 있습니다. 커서를 다른 곳으로 옮겨주세요.
마지막에 입력한 사람의 코드만 반영됩니다.
안내 문구는 실시간으로 커서 위치를 감지해서 동일 줄에서만 노출/숨김 처리됨
```
## 추가 설명
동시 편집 시 같은 줄에 두 명이 동시에 편집하면, 마지막으로 입력하거나 커서를 이동한 사람의 코드만 남게 됨
→ 혼란 방지를 위해 인라인 안내 메시지를 추가

기존 상단바 안내 대신, 코드 영역에 바로 안내되도록 구현하여 UX를 개선함